### PR TITLE
Fix landing SBOM release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,14 +68,6 @@ jobs:
       - run: npx playwright install --with-deps chromium firefox
       - run: npm run test:e2e
       - run: npm run test:e2e:cost
-      - name: Generate landing CycloneDX SBOM
-        working-directory: landing
-        run: npm sbom --sbom-format cyclonedx > landing-sbom.cdx.json
-      - uses: actions/upload-artifact@v4
-        with:
-          name: landing-metadata
-          path: landing/landing-sbom.cdx.json
-          if-no-files-found: error
       - name: Generate CycloneDX SBOM
         run: npm sbom --sbom-format cyclonedx > sbom.cdx.json
       - uses: actions/upload-artifact@v4
@@ -106,6 +98,13 @@ jobs:
       - run: npm run build
       - run: npx playwright install --with-deps chromium firefox webkit
       - run: npm run test:e2e
+      - name: Generate landing CycloneDX SBOM
+        run: npm sbom --sbom-format cyclonedx > landing-sbom.cdx.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: landing-metadata
+          path: landing/landing-sbom.cdx.json
+          if-no-files-found: error
 
   desktop:
     needs: verify

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Quizzer is a local-first desktop application and CLI that turns your PDF, Markdown, and text library into evidence-backed quizzes. Import a document once, then create focused tests with citations, custom learning goals, durable progress, and your choice of local models, signed-in coding agents, or API providers.
 
 > [!IMPORTANT]
-> Quizzer is preparing its first public beta (`1.0.0-beta.1`). No installer has been published yet. Until one appears on [GitHub Releases](https://github.com/Somethings1/quizzer/releases), build from source and do not rely on the commands below. Beta downloads use a Quizzer-signed manifest and verified checksums, but currently have no paid Apple notarization or Windows publisher certificate; the installer reports that limitation explicitly.
+> Quizzer is preparing its first public beta. No installer has been published yet. Until one appears on [GitHub Releases](https://github.com/Somethings1/quizzer/releases), build from source and do not rely on the commands below. Beta downloads use a Quizzer-signed manifest and verified checksums, but currently have no paid Apple notarization or Windows publisher certificate; the installer reports that limitation explicitly.
 
 The current beta foundation includes a resumable first-run walkthrough, reversible Simple and Advanced modes, hardware-aware Lite/Balanced/Max profiles, per-test learning instructions, source-span provenance, and crash-safe indexing and generation. Existing libraries are preserved during upgrade and are not forced through first-run setup.
 

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -313,7 +313,7 @@ app.whenReady().then(async () => {
   credentialVault = new CredentialVault(join(app.getPath('userData'), 'credentials.json'), safeStorage);
   desktopUpdater = new DesktopUpdater({
     userDataDir: app.getPath('userData'),
-    currentVersion: app.getVersion() || '1.0.0-beta.1',
+    currentVersion: app.getVersion() || '1.0.0-beta.2',
     isPackaged: app.isPackaged,
     fetch: net.fetch,
     trustedKeys: RELEASE_TRUSTED_KEYS,

--- a/desktop/updater.mjs
+++ b/desktop/updater.mjs
@@ -469,7 +469,7 @@ export const defaultLauncher = async (filePath, format, platform) => {
 export class DesktopUpdater {
   constructor(options = {}) {
     this.userDataDir = options.userDataDir || '';
-    this.currentVersion = options.currentVersion || '1.0.0-beta.1';
+    this.currentVersion = options.currentVersion || '1.0.0-beta.2';
     this.platform = detectPlatform(options.platform || process.platform);
     this.architecture = detectArch(options.architecture || process.arch);
     this.repository = CANONICAL_REPOSITORY;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quizzer",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quizzer",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Quizzer contributors",
   "license": "Apache-2.0",
   "private": true,
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "type": "module",
   "main": "desktop/main.mjs",
   "bin": {

--- a/test/release-workflow.test.mjs
+++ b/test/release-workflow.test.mjs
@@ -49,9 +49,12 @@ test('release validates packages and gates optional native signing explicitly', 
 
 test('release publishes separate application and landing SBOMs', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
+  const verifyJob = workflow.slice(workflow.indexOf('\n  verify:'), workflow.indexOf('\n  landing:'));
+  const landingJob = workflow.slice(workflow.indexOf('\n  landing:'), workflow.indexOf('\n  desktop:'));
 
   assert.match(workflow, /name: Generate CycloneDX SBOM/);
-  assert.match(workflow, /name: Generate landing CycloneDX SBOM\n\s+working-directory: landing\n\s+run: npm sbom --sbom-format cyclonedx > landing-sbom\.cdx\.json/);
+  assert.doesNotMatch(verifyJob, /Generate landing CycloneDX SBOM/);
+  assert.match(landingJob, /name: Generate landing CycloneDX SBOM\n\s+run: npm sbom --sbom-format cyclonedx > landing-sbom\.cdx\.json/);
   assert.match(workflow, /name: landing-metadata\n\s+path: landing\/landing-sbom\.cdx\.json/);
   assert.match(workflow, /landing-metadata\/landing-sbom\.cdx\.json/);
   assert.match(workflow, /release-bundle\/landing-sbom\.cdx\.json/);


### PR DESCRIPTION
## Summary
- generate the landing CycloneDX SBOM in the job that installed landing dependencies
- assert the SBOM step cannot drift back into the root-only verify job
- advance the unpublished candidate to 1.0.0-beta.2 without retagging beta.1

## Verification
- release/updater unit tests: 19 passed
- application lint and build passed
- landing SBOM generated and parsed: 560 components