### PR TITLE
Load embedded LanceDB addon in standalone CLI

### DIFF
--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -313,7 +313,7 @@ app.whenReady().then(async () => {
   credentialVault = new CredentialVault(join(app.getPath('userData'), 'credentials.json'), safeStorage);
   desktopUpdater = new DesktopUpdater({
     userDataDir: app.getPath('userData'),
-    currentVersion: app.getVersion() || '1.0.0-beta.2',
+    currentVersion: app.getVersion() || '1.0.0-beta.3',
     isPackaged: app.isPackaged,
     fetch: net.fetch,
     trustedKeys: RELEASE_TRUSTED_KEYS,

--- a/desktop/updater.mjs
+++ b/desktop/updater.mjs
@@ -469,7 +469,7 @@ export const defaultLauncher = async (filePath, format, platform) => {
 export class DesktopUpdater {
   constructor(options = {}) {
     this.userDataDir = options.userDataDir || '';
-    this.currentVersion = options.currentVersion || '1.0.0-beta.2';
+    this.currentVersion = options.currentVersion || '1.0.0-beta.3';
     this.platform = detectPlatform(options.platform || process.platform);
     this.architecture = detectArch(options.architecture || process.arch);
     this.repository = CANONICAL_REPOSITORY;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quizzer",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quizzer",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Quizzer contributors",
   "license": "Apache-2.0",
   "private": true,
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "type": "module",
   "main": "desktop/main.mjs",
   "bin": {

--- a/scripts/build-cli-sea.mjs
+++ b/scripts/build-cli-sea.mjs
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { build } from 'esbuild';
+import { seaLanceDbPlugin } from './sea-lancedb-plugin.mjs';
 
 const execFileAsync = promisify(execFile);
 const projectDirectory = resolve(import.meta.dirname, '..');
@@ -60,7 +61,7 @@ await build({
         path: join(projectDirectory, 'scripts', 'sea-better-sqlite3.mjs'),
       }));
     },
-  }],
+  }, seaLanceDbPlugin(projectDirectory)],
 });
 
 await writeFile(configPath, `${JSON.stringify({

--- a/scripts/sea-lancedb-native.cjs
+++ b/scripts/sea-lancedb-native.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+const nativeLibraryPath = process.env.NAPI_RS_NATIVE_LIBRARY_PATH;
+if (!nativeLibraryPath) {
+  throw new Error('Quizzer SEA must materialize the LanceDB native addon before loading LanceDB');
+}
+
+const nativeModule = { exports: {} };
+process.dlopen(nativeModule, nativeLibraryPath);
+module.exports = nativeModule.exports;

--- a/scripts/sea-lancedb-plugin.mjs
+++ b/scripts/sea-lancedb-plugin.mjs
@@ -1,0 +1,12 @@
+import { join } from 'node:path';
+
+export const seaLanceDbPlugin = projectDirectory => ({
+  name: 'quizzer-embedded-lancedb',
+  setup(buildContext) {
+    buildContext.onResolve({ filter: /^(?:\.\.\/|\.\/)native(?:\.js)?$/ }, args => {
+      const importer = args.importer.replaceAll('\\', '/');
+      if (!importer.includes('node_modules/@lancedb/lancedb/dist/')) return undefined;
+      return { path: join(projectDirectory, 'scripts', 'sea-lancedb-native.cjs') };
+    });
+  },
+});

--- a/test/sea-lancedb-loader.test.mjs
+++ b/test/sea-lancedb-loader.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { build } from 'esbuild';
+import { seaLanceDbPlugin } from '../scripts/sea-lancedb-plugin.mjs';
+
+const projectDirectory = resolve(import.meta.dirname, '..');
+const require = createRequire(import.meta.url);
+
+const lanceDbTarget = process.platform === 'darwin'
+  ? `@lancedb/lancedb-darwin-${process.arch}`
+  : process.platform === 'win32'
+    ? `@lancedb/lancedb-win32-${process.arch}-msvc`
+    : `@lancedb/lancedb-linux-${process.arch}-gnu`;
+
+test('SEA bundling replaces LanceDB platform probing with the host-addon shim', async () => {
+  const result = await build({
+    entryPoints: [resolve(projectDirectory, 'server', 'dense-index.mjs')],
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: `node${process.versions.node.split('.')[0]}`,
+    write: false,
+    metafile: true,
+    plugins: [seaLanceDbPlugin(projectDirectory)],
+  });
+
+  const inputs = Object.keys(result.metafile.inputs).map(path => path.replaceAll('\\', '/'));
+  assert.ok(inputs.some(path => path.endsWith('scripts/sea-lancedb-native.cjs')));
+  assert.ok(!inputs.some(path => path.endsWith('@lancedb/lancedb/dist/native.js')));
+  assert.ok(!inputs.some(path => path.endsWith('.node')));
+});
+
+test('SEA LanceDB shim loads the selected N-API addon directly', () => {
+  const packageEntry = require.resolve(lanceDbTarget);
+  const packageDirectory = dirname(packageEntry);
+  const addonName = process.platform === 'darwin'
+    ? `lancedb.${process.arch === 'arm64' ? 'darwin-arm64' : 'darwin-x64'}.node`
+    : process.platform === 'win32'
+      ? `lancedb.win32-${process.arch}-msvc.node`
+      : `lancedb.linux-${process.arch}-gnu.node`;
+  const previous = process.env.NAPI_RS_NATIVE_LIBRARY_PATH;
+  process.env.NAPI_RS_NATIVE_LIBRARY_PATH = resolve(packageDirectory, addonName);
+  try {
+    const binding = require('../scripts/sea-lancedb-native.cjs');
+    assert.equal(typeof binding.Connection, 'function');
+  } finally {
+    if (previous === undefined) delete process.env.NAPI_RS_NATIVE_LIBRARY_PATH;
+    else process.env.NAPI_RS_NATIVE_LIBRARY_PATH = previous;
+  }
+});


### PR DESCRIPTION
## Summary
- replace LanceDB platform probing with a SEA-specific native-addon shim
- load the materialized addon directly through `process.dlopen`
- add regression coverage proving no `.node` files or generated platform loader enter the bundle
- advance the immutable beta candidate version to `1.0.0-beta.3`

## Verification
- `npm test` (386 passed)
- `npm run lint`
- `npm run build`
- direct host native-addon loading test