### PR TITLE
Use supported Node runtime for Electron release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,11 @@ jobs:
           ditto -c -k --keepParent out/cli/quizzer out/cli/quizzer-notarization.zip
           xcrun notarytool submit out/cli/quizzer-notarization.zip --apple-id "$APPLE_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
           rm out/cli/quizzer-notarization.zip
+      - name: Use supported Node.js for Electron packaging
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
       - name: Build desktop distributables
         run: npm run make:desktop
       - name: Notarize macOS distributables

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ The current beta foundation includes a resumable first-run walkthrough, reversib
 Once a validated release is published, macOS and Linux users can install the desktop app and standalone CLI per-user with:
 
 ```sh
-curl -fsSL https://github.com/Somethings1/quizzer/releases/download/v1.0.0-beta.3/install.sh | sh
+curl -fsSL https://github.com/Somethings1/quizzer/releases/download/v1.0.0-beta.4/install.sh | sh
 ```
 
 On Windows, run this in PowerShell:
 
 ```powershell
-irm https://github.com/Somethings1/quizzer/releases/download/v1.0.0-beta.3/install.ps1 | iex
+irm https://github.com/Somethings1/quizzer/releases/download/v1.0.0-beta.4/install.ps1 | iex
 ```
 
 The scripts do not require Node.js, Python, or Git. They select the correct x64 or arm64 build, verify the Ed25519-signed release manifest and SHA-256 checksums, install `quizzer` on the user PATH, register the desktop application, and launch onboarding. Until native signing is enabled, macOS and Windows may show an unidentified-developer or unknown-publisher warning.

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -313,7 +313,7 @@ app.whenReady().then(async () => {
   credentialVault = new CredentialVault(join(app.getPath('userData'), 'credentials.json'), safeStorage);
   desktopUpdater = new DesktopUpdater({
     userDataDir: app.getPath('userData'),
-    currentVersion: app.getVersion() || '1.0.0-beta.3',
+    currentVersion: app.getVersion() || '1.0.0-beta.4',
     isPackaged: app.isPackaged,
     fetch: net.fetch,
     trustedKeys: RELEASE_TRUSTED_KEYS,

--- a/desktop/updater.mjs
+++ b/desktop/updater.mjs
@@ -469,7 +469,7 @@ export const defaultLauncher = async (filePath, format, platform) => {
 export class DesktopUpdater {
   constructor(options = {}) {
     this.userDataDir = options.userDataDir || '';
-    this.currentVersion = options.currentVersion || '1.0.0-beta.3';
+    this.currentVersion = options.currentVersion || '1.0.0-beta.4';
     this.platform = detectPlatform(options.platform || process.platform);
     this.architecture = detectArch(options.architecture || process.arch);
     this.repository = CANONICAL_REPOSITORY;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quizzer",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quizzer",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Quizzer contributors",
   "license": "Apache-2.0",
   "private": true,
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "type": "module",
   "main": "desktop/main.mjs",
   "bin": {

--- a/test/release-workflow.test.mjs
+++ b/test/release-workflow.test.mjs
@@ -17,6 +17,8 @@ test('release validates packages and gates optional native signing explicitly', 
 
   ordered(workflow, 'Install Linux packaging tools', 'Cache verified AppImage runtime');
   ordered(workflow, 'Cache verified AppImage runtime', 'Build desktop distributables');
+  ordered(workflow, 'Build standalone CLI', 'Use supported Node.js for Electron packaging');
+  ordered(workflow, 'Use supported Node.js for Electron packaging', 'Build desktop distributables');
   ordered(workflow, 'Build desktop distributables', 'Verify Apple signatures and notarization');
   ordered(workflow, 'Build desktop distributables', 'Notarize macOS distributables');
   ordered(workflow, 'Notarize macOS distributables', 'Verify Apple signatures and notarization');
@@ -27,6 +29,7 @@ test('release validates packages and gates optional native signing explicitly', 
   ordered(workflow, 'Verify Linux packages and AppImage', 'Normalize release artifacts');
   assert.match(workflow, /sudo apt-get install --yes fakeroot rpm squashfs-tools/);
   assert.match(workflow, /node scripts\/prepare-appimage-runtime\.mjs --arch "\$\{\{\s*matrix\.architecture\s*\}\}"/);
+  assert.match(workflow, /name: Use supported Node\.js for Electron packaging\n\s+uses: actions\/setup-node@v4\n\s+with:\n\s+node-version: 22/);
   assert.match(workflow, /APPIMAGE_PATH="\$\(require_single_artifact '\*\.appimage'\)"/);
   assert.match(workflow, /AI_MAGIC="\$\(dd if="\$APPIMAGE_PATH" bs=1 skip=8 count=3 2>\/dev\/null\)"/);
   assert.match(workflow, /codesign --verify --strict --verbose=2 out\/cli\/quizzer/);


### PR DESCRIPTION
## Summary
- keep Node 26 for building standalone SEA executables
- switch the release matrix to Node 22 before invoking Electron Forge
- add workflow-order regression coverage
- advance the immutable candidate to `1.0.0-beta.4` and update install commands

## Root cause
Electron Forge exited without producing its package directories under Node 26 on every completed beta.3 platform job. Normal desktop CI and a clean local package run use Node 22 successfully.

## Verification
- clean `npm run make:desktop`
- `npm run verify:desktop-fuses` (9 fuses)
- `npm test` (386 passed)
- `npm run lint`
- `npm run build`
- release workflow structure tests