### PR TITLE
Rebuild macOS release helpers for packaging runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - name: Rebuild macOS packaging helpers for Node.js 22
+        if: matrix.platform == 'macos'
+        run: npm rebuild macos-alias fs-xattr
       - name: Build desktop distributables
         run: npm run make:desktop
       - name: Notarize macOS distributables

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ The current beta foundation includes a resumable first-run walkthrough, reversib
 Once a validated release is published, macOS and Linux users can install the desktop app and standalone CLI per-user with:
 
 ```sh
-curl -fsSL https://github.com/Somethings1/quizzer/releases/download/v1.0.0-beta.4/install.sh | sh
+curl -fsSL https://github.com/Somethings1/quizzer/releases/download/v1.0.0-beta.5/install.sh | sh
 ```
 
 On Windows, run this in PowerShell:
 
 ```powershell
-irm https://github.com/Somethings1/quizzer/releases/download/v1.0.0-beta.4/install.ps1 | iex
+irm https://github.com/Somethings1/quizzer/releases/download/v1.0.0-beta.5/install.ps1 | iex
 ```
 
 The scripts do not require Node.js, Python, or Git. They select the correct x64 or arm64 build, verify the Ed25519-signed release manifest and SHA-256 checksums, install `quizzer` on the user PATH, register the desktop application, and launch onboarding. Until native signing is enabled, macOS and Windows may show an unidentified-developer or unknown-publisher warning.

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -313,7 +313,7 @@ app.whenReady().then(async () => {
   credentialVault = new CredentialVault(join(app.getPath('userData'), 'credentials.json'), safeStorage);
   desktopUpdater = new DesktopUpdater({
     userDataDir: app.getPath('userData'),
-    currentVersion: app.getVersion() || '1.0.0-beta.4',
+    currentVersion: app.getVersion() || '1.0.0-beta.5',
     isPackaged: app.isPackaged,
     fetch: net.fetch,
     trustedKeys: RELEASE_TRUSTED_KEYS,

--- a/desktop/updater.mjs
+++ b/desktop/updater.mjs
@@ -469,7 +469,7 @@ export const defaultLauncher = async (filePath, format, platform) => {
 export class DesktopUpdater {
   constructor(options = {}) {
     this.userDataDir = options.userDataDir || '';
-    this.currentVersion = options.currentVersion || '1.0.0-beta.4';
+    this.currentVersion = options.currentVersion || '1.0.0-beta.5';
     this.platform = detectPlatform(options.platform || process.platform);
     this.architecture = detectArch(options.architecture || process.arch);
     this.repository = CANONICAL_REPOSITORY;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quizzer",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quizzer",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Quizzer contributors",
   "license": "Apache-2.0",
   "private": true,
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "type": "module",
   "main": "desktop/main.mjs",
   "bin": {

--- a/test/release-workflow.test.mjs
+++ b/test/release-workflow.test.mjs
@@ -18,7 +18,8 @@ test('release validates packages and gates optional native signing explicitly', 
   ordered(workflow, 'Install Linux packaging tools', 'Cache verified AppImage runtime');
   ordered(workflow, 'Cache verified AppImage runtime', 'Build desktop distributables');
   ordered(workflow, 'Build standalone CLI', 'Use supported Node.js for Electron packaging');
-  ordered(workflow, 'Use supported Node.js for Electron packaging', 'Build desktop distributables');
+  ordered(workflow, 'Use supported Node.js for Electron packaging', 'Rebuild macOS packaging helpers for Node.js 22');
+  ordered(workflow, 'Rebuild macOS packaging helpers for Node.js 22', 'Build desktop distributables');
   ordered(workflow, 'Build desktop distributables', 'Verify Apple signatures and notarization');
   ordered(workflow, 'Build desktop distributables', 'Notarize macOS distributables');
   ordered(workflow, 'Notarize macOS distributables', 'Verify Apple signatures and notarization');
@@ -30,6 +31,7 @@ test('release validates packages and gates optional native signing explicitly', 
   assert.match(workflow, /sudo apt-get install --yes fakeroot rpm squashfs-tools/);
   assert.match(workflow, /node scripts\/prepare-appimage-runtime\.mjs --arch "\$\{\{\s*matrix\.architecture\s*\}\}"/);
   assert.match(workflow, /name: Use supported Node\.js for Electron packaging\n\s+uses: actions\/setup-node@v4\n\s+with:\n\s+node-version: 22/);
+  assert.match(workflow, /name: Rebuild macOS packaging helpers for Node\.js 22\n\s+if: matrix\.platform == 'macos'\n\s+run: npm rebuild macos-alias fs-xattr/);
   assert.match(workflow, /APPIMAGE_PATH="\$\(require_single_artifact '\*\.appimage'\)"/);
   assert.match(workflow, /AI_MAGIC="\$\(dd if="\$APPIMAGE_PATH" bs=1 skip=8 count=3 2>\/dev\/null\)"/);
   assert.match(workflow, /codesign --verify --strict --verbose=2 out\/cli\/quizzer/);


### PR DESCRIPTION
## Summary
- rebuild the native `macos-alias` and `fs-xattr` DMG helpers after switching from Node 26 to Node 22
- keep the rebuild scoped to macOS release jobs
- lock runtime/rebuild/build ordering with workflow tests
- advance the immutable candidate to `1.0.0-beta.5`

## Root cause
The beta.4 DMG maker loaded `macos-alias` under Node 22 after `npm ci` had compiled it for Node 26 (`NODE_MODULE_VERSION 147` versus `127`). Windows x64 and Linux x64/arm64 passed.

## Verification
- `npm rebuild macos-alias fs-xattr`
- clean `npm run make:desktop` produced DMG and ZIP
- `npm run verify:desktop-fuses` (9 fuses)
- `npm test` (386 passed)
- release workflow structure tests