### PR TITLE
Fix installer download progress

### DIFF
--- a/installers/install.ps1.in
+++ b/installers/install.ps1.in
@@ -1,5 +1,5 @@
 $ErrorActionPreference = 'Stop'
-$ProgressPreference = 'SilentlyContinue'
+$ProgressPreference = 'Continue'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $ReleaseBaseUrl = '__QUIZZER_RELEASE_BASE_URL__'
@@ -15,7 +15,14 @@ function Fail([string] $Message) {
 function Download-File([string] $Url, [string] $Destination) {
   $Uri = [Uri] $Url
   if ($Uri.Scheme -ne 'https') { Fail "Refusing a non-HTTPS download: $Url" }
-  Invoke-WebRequest -UseBasicParsing -Uri $Uri -OutFile $Destination
+  $Name = Split-Path -Leaf $Destination
+  Write-Host "`nDownloading $Name"
+  Write-Progress -Activity 'Downloading Quizzer' -Status $Name
+  try {
+    Invoke-WebRequest -UseBasicParsing -Uri $Uri -OutFile $Destination
+  } finally {
+    Write-Progress -Activity 'Downloading Quizzer' -Completed
+  }
 }
 
 function Assert-Artifact([object] $Artifact, [string] $ExpectedName, [string] $Destination) {

--- a/installers/install.sh.in
+++ b/installers/install.sh.in
@@ -16,7 +16,10 @@ require_command() {
 }
 
 download() {
-  curl --fail --location --silent --show-error --retry 3 --proto '=https' --tlsv1.2 "$1" --output "$2"
+  download_url=$1
+  download_destination=$2
+  printf '\nDownloading %s\n' "$(basename "$download_destination")"
+  curl --fail --location --progress-bar --show-error --retry 3 --proto '=https' --tlsv1.2 "$download_url" --output "$download_destination"
 }
 
 sha256_file() {
@@ -83,7 +86,7 @@ cat > "$public_key_path" <<'QUIZZER_RELEASE_PUBLIC_KEY'
 __QUIZZER_RELEASE_PUBLIC_KEY_PEM__
 QUIZZER_RELEASE_PUBLIC_KEY
 
-printf 'Downloading signed Quizzer release metadata…\n'
+printf 'Fetching signed Quizzer release metadata…\n'
 download "$release_base_url/$metadata_name" "$metadata_path"
 download "$release_base_url/$signature_name" "$signature_path"
 

--- a/test/release-installers.test.mjs
+++ b/test/release-installers.test.mjs
@@ -62,8 +62,12 @@ test('renders installers with the signing key and exact verifiable release metad
     assert.match(powershell, /releases\/download\/v1\.0\.0-beta\.1/);
     assert.match(shell, /expected_apple_team_id='ABCDE12345'/);
     assert.match(shell, /TeamIdentifier/);
+    assert.match(shell, /curl .*--progress-bar/);
+    assert.match(shell, /Downloading %s/);
     assert.match(powershell, /ExpectedCertificateSha256 = 'ABAB/);
     assert.match(powershell, /SignerCertificate\.RawData/);
+    assert.match(powershell, /\$ProgressPreference = 'Continue'/);
+    assert.match(powershell, /Write-Progress -Activity 'Downloading Quizzer'/);
     assert.ok(shell.indexOf('cli_team_id=') < shell.indexOf('"$cli_download" release verify'));
     assert.ok(powershell.indexOf('Assert-Authenticode $CliDownload') < powershell.indexOf('& $CliDownload release verify'));
     assert.equal((await stat(result.shell)).mode & 0o777, 0o755);


### PR DESCRIPTION
Closes #9

## Summary
- show a live curl progress bar for Unix installer downloads
- restore and label PowerShell transfer progress
- cover progress behavior in release-installer tests

## Verification
- node --test test/release-installers.test.mjs
- npm run lint
- npm run build