### PR TITLE
Fix setup flow through document import

### DIFF
--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { ensureServiceToken } from '../server/auth.mjs';
 import { CredentialVault } from './credential-vault.mjs';
 import { isAllowedExternalUrl, isTrustedRendererUrl } from './security.mjs';
-import { serviceRestartDelay, waitForServiceReady } from './service-process.mjs';
+import { executableSearchPath, serviceRestartDelay, waitForServiceReady } from './service-process.mjs';
 import { protectedBackgroundFallback, summarizeBackgroundState } from './background-policy.mjs';
 import { DesktopUpdater } from './updater.mjs';
 import { validateUpdaterCheckOptions, validateUpdaterApplyOptions } from './updater-ipc.mjs';
@@ -149,6 +149,7 @@ const startService = async () => {
     cwd: userData,
     env: {
       ...process.env,
+      PATH: executableSearchPath(process.env, { homeDirectory: app.getPath('home') }),
       QUIZZER_APP_DATA_DIR: userData,
       QUIZZER_DATABASE_PATH: join(userData, 'data', 'quizzer.sqlite'),
       QUIZZER_RESOURCE_DIR: app.isPackaged ? process.resourcesPath : projectDirectory,

--- a/desktop/service-process.mjs
+++ b/desktop/service-process.mjs
@@ -1,3 +1,37 @@
+import { join } from 'node:path';
+
+export const executableSearchPath = (environment = process.env, {
+  platform = process.platform,
+  homeDirectory = environment.HOME || environment.USERPROFILE || '',
+} = {}) => {
+  const pathDelimiter = platform === 'win32' ? ';' : ':';
+  const existing = String(environment.PATH || environment.Path || '').split(pathDelimiter).filter(Boolean);
+  const candidates = platform === 'win32'
+    ? [
+        environment.APPDATA && join(environment.APPDATA, 'npm'),
+        environment.LOCALAPPDATA && join(environment.LOCALAPPDATA, 'Microsoft', 'WinGet', 'Links'),
+        environment.LOCALAPPDATA && join(environment.LOCALAPPDATA, 'Programs', 'Ollama'),
+      ]
+    : [
+        homeDirectory && join(homeDirectory, '.local', 'bin'),
+        homeDirectory && join(homeDirectory, '.npm-global', 'bin'),
+        homeDirectory && join(homeDirectory, '.npm', 'bin'),
+        homeDirectory && join(homeDirectory, '.volta', 'bin'),
+        homeDirectory && join(homeDirectory, '.bun', 'bin'),
+        homeDirectory && join(homeDirectory, '.cargo', 'bin'),
+        platform === 'darwin' && homeDirectory && join(homeDirectory, 'Library', 'pnpm'),
+        platform === 'darwin' && '/opt/homebrew/bin',
+        '/usr/local/bin',
+      ];
+  const seen = new Set();
+  return [...existing, ...candidates.filter(Boolean)].filter(entry => {
+    const key = platform === 'win32' ? entry.toLowerCase() : entry;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).join(pathDelimiter);
+};
+
 export const isValidServicePort = port => Number.isSafeInteger(port) && port >= 1 && port <= 65_535;
 
 export const serviceRestartDelay = attempt => {

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -123,6 +123,10 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await expect(page.locator('[data-onboarding-target="document"]').filter({ visible: true }).first()).toBeVisible();
   await expect(page.locator('.onboarding-coachmark')).toBeVisible();
   await page.locator('.onboarding-drawer').getByRole('button').filter({ hasText: 'Add document' }).click();
+  const documentDialog = page.getByRole('dialog', { name: 'Add documents' });
+  await expect(documentDialog).toBeVisible();
+  await expect(documentDialog.getByRole('combobox', { name: 'Document extraction method' })).toHaveCount(0);
+  await expect(page.locator('.onboarding-coachmark')).toBeHidden();
   await page.locator('input[type="file"]').setInputFiles({
     name: 'coordination.md',
     mimeType: 'text/markdown',

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -104,9 +104,18 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await expect(page.getByRole('region', { name: 'Onboarding hint' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Dismiss walkthrough hint' })).toBeVisible();
   expect(await page.locator('.onboarding-coachmark').evaluate(element => ({ animation: getComputedStyle(element).animationName, duration: getComputedStyle(element).transitionDuration }))).toEqual({ animation: 'none', duration: '0s' });
+  await onboarding.getByRole('button', { name: 'Review AI settings' }).click();
+  const pluginsDialog = page.getByRole('dialog', { name: 'Plugins & models' });
+  await expect(pluginsDialog).toBeVisible();
+  await expect(pluginsDialog.getByRole('tab', { name: 'Models' })).toBeVisible();
+  await expect(pluginsDialog.getByRole('tab', { name: 'Plugins' })).toBeVisible();
+  await expect(page.locator('.onboarding-coachmark')).toBeHidden();
+  await pluginsDialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(page.locator('.onboarding-coachmark')).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(page.locator('.onboarding-coachmark')).toBeHidden();
-  await page.getByRole('button', { name: 'Resume setup' }).last().click();
+  await onboarding.getByRole('button', { name: 'Close' }).click();
+  await page.getByRole('button', { name: 'Resume setup', exact: true }).click();
   await expect(page.locator('.onboarding-coachmark')).toBeVisible();
   await page.getByRole('button', { name: 'Continue' }).click();
 

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -85,11 +85,16 @@ test('resumes real onboarding and finishes through durable quiz practice', async
 
   await expect(page.getByRole('heading', { name: 'Learn from your own material' })).toBeVisible();
   const onboarding = page.locator('.onboarding-drawer');
+  await expect(onboarding.getByRole('progressbar', { name: 'Onboarding progress' })).toHaveCount(0);
+  await expect(onboarding.locator('.ant-steps-item')).toHaveCount(2);
   await onboarding.getByText('Simple', { exact: true }).click();
   await expect(onboarding.getByRole('radio', { name: /^Simple/ })).toBeChecked();
   await expect(page.getByRole('button', { name: 'Switch to Advanced mode' })).toBeVisible();
   await page.getByRole('button', { name: 'Continue' }).click();
   await expect(page.getByRole('heading', { name: 'Choose a hardware profile' })).toBeVisible();
+  await expect(onboarding.locator('.ant-steps-item')).toHaveCount(3);
+  await expect(page.getByRole('button', { name: 'Use recommendation' })).toHaveCount(0);
+  await expect(onboarding.getByRole('radio', { checked: true })).toHaveCount(1);
   await expect(page.getByRole('button', { name: 'Continue' })).toBeEnabled({ timeout: 15_000 });
   await page.getByRole('button', { name: 'Continue' }).click();
   await expect(page.getByRole('heading', { name: 'Configure your AI' })).toBeVisible();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,7 +162,8 @@ function AppShell({ dark, onToggleTheme }: ShellProps) {
       {profile && <OnboardingGuide open={showOnboarding && !profile.onboarding.completedAt && !profile.onboarding.skipped} profile={profile}
         onPause={() => setShowOnboarding(false)} onFinish={() => { setShowOnboarding(false); select(null); }}
         onOpenPlugins={() => setShowPluginsModal(true)} onAddDocument={() => setShowDocumentModal(true)} onAddTest={() => setShowAddModal(true)}
-        onOpenTest={id => { setSelection({ kind: 'test', id }); setShowOnboarding(false); }} />}
+        onOpenTest={id => { setSelection({ kind: 'test', id }); setShowOnboarding(false); }}
+        overlayOpen={showPluginsModal || showDocumentModal || showAddModal || showPromptStudio || showGenerationCenter || showSettingsModal || showCommandPalette} />}
       {session?.mode !== 'taking' && <GenerationActivity onOpen={() => setShowGenerationCenter(true)} />}
     </Layout>
   </>;

--- a/src/components/AddDocumentModal.tsx
+++ b/src/components/AddDocumentModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Alert, Button, Input, List, Modal, Select, Space, Spin, Tag, Upload, Typography } from 'antd';
+import { Alert, Button, Input, List, Modal, Space, Spin, Tag, Upload, Typography } from 'antd';
 import { InboxOutlined, ReloadOutlined } from '@ant-design/icons';
 import type { RcFile } from 'antd/es/upload';
 import { v4 as uuidv4 } from 'uuid';
@@ -38,35 +38,32 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
   const toolSettings = getProviderSettings().enabledTools;
   const [files, setFiles] = useState<PendingDocument[]>([]);
   const [saving, setSaving] = useState(false);
-  const [converter, setConverter] = useState<'automatic' | 'basic'>('automatic');
   const message = getMessageApi();
 
   const update = (id: string, changes: Partial<PendingDocument>) =>
     setFiles(current => current.map(item => item.id === id ? { ...item, ...changes } : item));
 
-  const extract = async (id: string, file: RcFile, mode: 'automatic' | 'basic') => {
+  const extract = async (id: string, file: RcFile) => {
     update(id, { status: 'extracting', stage: 'Reading document…', error: undefined, extracted: undefined });
     try {
       const isPdf = file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
       let extracted: Pick<StoredDocument, 'content' | 'pageCount' | 'images' | 'parserVersion'> = isPdf
         ? { ...await extractPdf(file), parserVersion: 'pdfjs-5.3.31' }
         : { content: await file.text(), pageCount: undefined, parserVersion: 'utf8-1' };
-      if (mode === 'automatic') {
-        update(id, { stage: isPdf ? 'Running the configured document extractor…' : 'Checking the configured document extractor…' });
-        try {
-          const dataUrl = await new Promise<string>((resolve, reject) => {
-            const reader = new FileReader();
-            reader.onload = () => resolve(String(reader.result));
-            reader.onerror = () => reject(reader.error);
-            reader.readAsDataURL(file);
-          });
-          const response = await serviceFetch('/api/extract', {
-            method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: file.name, data: dataUrl.split(',')[1], ocrEnabled: toolSettings.ocr }),
-          });
-          if (response.ok) extracted = await response.json() as typeof extracted;
-        } catch { /* Marker is optional; retain the basic extraction. */ }
-      }
+      update(id, { stage: isPdf ? 'Running the configured document extractor…' : 'Checking the configured document extractor…' });
+      try {
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(String(reader.result));
+          reader.onerror = () => reject(reader.error);
+          reader.readAsDataURL(file);
+        });
+        const response = await serviceFetch('/api/extract', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: file.name, data: dataUrl.split(',')[1], ocrEnabled: toolSettings.ocr }),
+        });
+        if (response.ok) extracted = await response.json() as typeof extracted;
+      } catch { /* The configured extractor is optional; retain the basic extraction. */ }
       if (!extracted.content.trim()) throw new Error('No readable text was found in this document.');
       update(id, {
         status: 'ready', stage: undefined,
@@ -94,7 +91,7 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
       stage: 'Queued…',
     };
     setFiles(current => [...current, pending]);
-    void extract(id, file, converter);
+    void extract(id, file);
     return false;
   };
 
@@ -143,12 +140,8 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
           : null}
     </>}>
       <Typography.Paragraph type="secondary">
-        Documents are extracted now and saved to your local library. Creating a quiz is a separate step.
+        Quizzer automatically uses your configured extractor, then falls back to built-in text extraction when needed. You can change the extractor later and re-extract a saved document.
       </Typography.Paragraph>
-      <Select aria-label="Document extraction method" value={converter} onChange={setConverter} style={{ width: 280, marginBottom: 12 }} options={[
-        { value: 'automatic' as const, label: 'Automatic (configured extractor)' },
-        { value: 'basic', label: 'Basic PDF text extraction' },
-      ]} />
       <Upload.Dragger data-onboarding-target="document" multiple showUploadList={false} beforeUpload={addFile} accept=".pdf,.txt,.md">
         <p className="ant-upload-drag-icon"><InboxOutlined /></p>
         <p className="ant-upload-text">Drop PDF, text, or Markdown documents here</p>
@@ -159,7 +152,7 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
       <List style={{ marginTop: 16, maxHeight: 330, overflow: 'auto' }} dataSource={files}
         renderItem={item => (
           <List.Item actions={item.status === 'error' ? [
-            <Button key="retry" size="small" icon={<ReloadOutlined />} onClick={() => void extract(item.id, item.file, converter)}>Retry</Button>,
+            <Button key="retry" size="small" icon={<ReloadOutlined />} onClick={() => void extract(item.id, item.file)}>Retry</Button>,
             <Button key="remove" danger size="small" onClick={() => setFiles(all => all.filter(file => file.id !== item.id))}>Remove</Button>,
           ] : [<Button key="remove" danger size="small" onClick={() => setFiles(all => all.filter(file => file.id !== item.id))}>Remove</Button>]}>
             <Space direction="vertical" style={{ width: '100%' }}>

--- a/src/components/OnboardingGuide.tsx
+++ b/src/components/OnboardingGuide.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Alert, Button, Card, Descriptions, Divider, Drawer, Input, Progress, Radio, Space, Spin, Steps, Tag, Typography } from 'antd';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Button, Card, Descriptions, Divider, Drawer, Input, Radio, Space, Spin, Steps, Tag, Typography } from 'antd';
 import { ApiOutlined, CheckCircleOutlined, FileAddOutlined, FormOutlined, LaptopOutlined, PlayCircleOutlined } from '@ant-design/icons';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db, type StoredAppProfile } from '../db/db';
@@ -18,6 +18,7 @@ interface Props {
   onAddDocument: () => void;
   onAddTest: () => void;
   onOpenTest: (id: string) => void;
+  overlayOpen: boolean;
 }
 
 const labels: Record<OnboardingStep, string> = {
@@ -44,7 +45,7 @@ const isVisibleTarget = (element: Element) => {
   return rect.width > 0 && rect.height > 0 && getComputedStyle(node).visibility !== 'hidden' && getComputedStyle(node).display !== 'none';
 };
 
-function OnboardingCoachMark({ step, open }: { step: OnboardingStep; open: boolean }) {
+function OnboardingCoachMark({ step, open, suspended }: { step: OnboardingStep; open: boolean; suspended: boolean }) {
   const copy = coachmarkCopy[step];
   const [target, setTarget] = useState<HTMLElement>();
   const [rect, setRect] = useState<DOMRect>();
@@ -52,7 +53,7 @@ function OnboardingCoachMark({ step, open }: { step: OnboardingStep; open: boole
 
   useEffect(() => { setDismissed(false); }, [open, step]);
   useEffect(() => {
-    if (!copy || (!open && step !== 'practice') || dismissed) { setTarget(undefined); setRect(undefined); return undefined; }
+    if (!copy || suspended || (!open && step !== 'practice') || dismissed) { setTarget(undefined); setRect(undefined); return undefined; }
     let frame = 0;
     let targetObserver: ResizeObserver | undefined;
     let observedTarget: HTMLElement | undefined;
@@ -93,9 +94,9 @@ function OnboardingCoachMark({ step, open }: { step: OnboardingStep; open: boole
       window.removeEventListener('keydown', keyboard);
       observer.disconnect();
     };
-  }, [copy, dismissed, open, step]);
+  }, [copy, dismissed, open, step, suspended]);
 
-  if (!copy || dismissed || !target || !rect || (!open && step !== 'practice')) return null;
+  if (!copy || dismissed || suspended || !target || !rect || (!open && step !== 'practice')) return null;
   const top = Math.max(12, Math.min(window.innerHeight - 150, rect.bottom + 12));
   const left = Math.max(12, Math.min(window.innerWidth - 332, rect.left));
   return <>
@@ -107,7 +108,7 @@ function OnboardingCoachMark({ step, open }: { step: OnboardingStep; open: boole
   </>;
 }
 
-export default function OnboardingGuide({ open, profile, onPause, onFinish, onOpenPlugins, onAddDocument, onAddTest, onOpenTest }: Props) {
+export default function OnboardingGuide({ open, profile, onPause, onFinish, onOpenPlugins, onAddDocument, onAddTest, onOpenTest, overlayOpen }: Props) {
   const configured = useConfiguredProviders();
   const library = useLiveQuery(async () => {
     const [documents, tests, jobs, drafts] = await Promise.all([db.documents.toArray(), db.tests.toArray(), db.generationJobs.toArray(), db.testDrafts.toArray()]);
@@ -115,6 +116,7 @@ export default function OnboardingGuide({ open, profile, onPause, onFinish, onOp
   }, []);
   const [hardware, setHardware] = useState<HardwareCapabilities>();
   const [hardwareError, setHardwareError] = useState('');
+  const recommendationApplied = useRef(false);
   const [instruction, setInstruction] = useState(profile.defaultLearningInstruction ?? '');
   const step = profile.onboarding.currentStep;
   const index = ONBOARDING_STEPS.indexOf(step);
@@ -124,9 +126,14 @@ export default function OnboardingGuide({ open, profile, onPause, onFinish, onOp
     if (!open || hardware || hardwareError) return;
     void serviceFetch('/api/system/capabilities').then(async response => {
       if (!response.ok) throw new Error('Hardware scan is unavailable');
-      setHardware(await response.json() as HardwareCapabilities);
+      const capabilities = await response.json() as HardwareCapabilities;
+      setHardware(capabilities);
+      if (!recommendationApplied.current && !profile.onboarding.completedSteps.includes('hardware')) {
+        recommendationApplied.current = true;
+        await setHardwareProfile(capabilities.recommendedProfile);
+      }
     }).catch(error => setHardwareError((error as Error).message));
-  }, [hardware, hardwareError, open]);
+  }, [hardware, hardwareError, open, profile.onboarding.completedSteps]);
 
   const onboardingDocument = library?.documents.find(document => document.id === profile.onboarding.documentId && document.content.trim());
   const generationJob = library?.jobs.find(job => job.id === profile.onboarding.generationJobId
@@ -158,11 +165,6 @@ export default function OnboardingGuide({ open, profile, onPause, onFinish, onOp
     await advanceOnboarding(step, ONBOARDING_STEPS[index + 1]);
   };
 
-  const chooseRecommended = async (capabilities: HardwareCapabilities) => {
-    setHardware(capabilities);
-    await setHardwareProfile(capabilities.recommendedProfile);
-  };
-
   const confirmSkip = () => getModalApi().confirm({
     title: 'Skip setup?',
     content: 'You can restart the walkthrough at any time from the sidebar. Your current documents and settings will stay intact.',
@@ -171,7 +173,7 @@ export default function OnboardingGuide({ open, profile, onPause, onFinish, onOp
   });
 
   return <>
-  <OnboardingCoachMark step={step} open={open} />
+  <OnboardingCoachMark step={step} open={open} suspended={overlayOpen} />
   <Drawer className="onboarding-drawer" title="Set up Quizzer" width={440} open={open} mask={index === 0} closable onClose={onPause}
     extra={<Button type="text" onClick={confirmSkip}>Skip</Button>}
     footer={<div className="onboarding-footer">
@@ -179,9 +181,11 @@ export default function OnboardingGuide({ open, profile, onPause, onFinish, onOp
       <Typography.Text type="secondary">Step {index + 1} of {ONBOARDING_STEPS.length}</Typography.Text>
       <Button type="primary" disabled={!requirementMet[step]} onClick={() => void next()}>{step === 'complete' ? 'Finish' : 'Continue'}</Button>
     </div>}>
-    <Progress aria-label="Onboarding progress" percent={Math.round(index / (ONBOARDING_STEPS.length - 1) * 100)} showInfo={false} />
-    <Steps size="small" current={index} direction="vertical" className="onboarding-steps"
-      items={ONBOARDING_STEPS.map(item => ({ title: labels[item], status: profile.onboarding.completedSteps.includes(item) ? 'finish' : item === step ? 'process' : 'wait' }))} />
+    <Steps size="small" current={index === 0 ? 0 : 1} direction="vertical" className="onboarding-steps"
+      items={ONBOARDING_STEPS.slice(Math.max(0, index - 1), Math.min(ONBOARDING_STEPS.length, index + 2)).map(item => {
+        const itemIndex = ONBOARDING_STEPS.indexOf(item);
+        return { title: labels[item], status: itemIndex < index ? 'finish' : itemIndex === index ? 'process' : 'wait' };
+      })} />
     <Divider />
 
     {step === 'welcome' && <Space direction="vertical" size="middle" style={{ width: '100%' }}>
@@ -204,8 +208,7 @@ export default function OnboardingGuide({ open, profile, onPause, onFinish, onOp
           { key: 'disk', label: 'Free disk', children: `${hardware.freeDiskGB} GB` },
           { key: 'arch', label: 'System', children: `${hardware.platform} ${hardware.architecture}` },
         ]} />
-        <Alert type="success" showIcon message={`${hardware.recommendedProfile.toUpperCase()} is recommended`} description={hardware.reasons.join(' ')}
-          action={<Button size="small" onClick={() => void chooseRecommended(hardware)}>Use recommendation</Button>} />
+        <Alert type="success" showIcon message={`${hardware.recommendedProfile.toUpperCase()} is recommended and selected`} description={hardware.reasons.join(' ')} />
       </>}
       <Radio.Group value={profile.hardwareProfile} onChange={event => void setHardwareProfile(event.target.value)}>
         <Space direction="vertical">{(['lite', 'balanced', 'max'] as HardwareProfileId[]).map(item => <Radio key={item} value={item}><strong>{item.toUpperCase()}</strong> — {profileDetails[item]}</Radio>)}</Space>

--- a/src/components/PluginsModal.tsx
+++ b/src/components/PluginsModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, AutoComplete, Button, Divider, Input, Modal, Select, Space, Spin, Switch, Tag, Typography } from 'antd';
+import { Alert, AutoComplete, Button, Divider, Input, Modal, Select, Space, Spin, Switch, Tabs, Tag, Typography } from 'antd';
 import { ApiOutlined, CheckCircleOutlined, CloudDownloadOutlined, DeleteOutlined, FolderOpenOutlined, LoginOutlined, ReloadOutlined, RollbackOutlined } from '@ant-design/icons';
 import type { GenerationProvider, InterfaceMode } from '../types';
 import {
@@ -298,7 +298,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
   };
 
   const installEmbeddingModel = () => {
-    const model = status?.embeddings.model;
+    const model = status?.embeddings?.model;
     if (!model) return message.warning('Embedding settings are still loading');
     getModalApi().confirm({
       title: `Download ${model} for dense retrieval?`,
@@ -495,7 +495,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         'retrieval.vectorIndexPlugin': vectorIndexPlugin,
       } });
       if (models['llama-cpp']?.trim()) {
-        await serviceJson('/api/integrations/llama-cpp/configure', 'POST', {
+        await serviceJson('/api/v1/integrations/llama-cpp/configure', 'POST', {
           endpoint: llamaCppEndpoint.trim() || 'http://127.0.0.1:8080/v1',
           model: models['llama-cpp'].trim(),
           confirmed: true,
@@ -512,7 +512,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
     }
   };
 
-  const markerWorking = status?.marker.job.state === 'working';
+  const markerWorking = status?.marker?.job.state === 'working';
   const ocrWorking = status?.ocr?.job.state === 'working';
   const embeddingsWorking = status?.embeddings?.job.state === 'working';
   const ollamaWorking = status?.ollama?.job.state === 'working';
@@ -562,7 +562,10 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         message={credentialStorage.available ? 'OS-protected credential storage is available' : 'Credentials will remain session-only'}
         description={credentialStorage.message} style={{ marginBottom: 16 }} />
       {statusError && <Alert type="error" showIcon message={statusError} action={<Button size="small" icon={<ReloadOutlined />} onClick={() => void refresh()}>Retry</Button>} />}
-      {!status && !statusError ? <div className="plugin-loading"><Spin /></div> : <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      {!status && !statusError ? <div className="plugin-loading"><Spin /></div> : <Tabs defaultActiveKey="models" items={[{
+        key: 'models',
+        label: 'Models',
+        children: <Space direction="vertical" size="middle" style={{ width: '100%' }}>
         <section className="plugin-card">
           <div className="plugin-card-heading">
             <div><Typography.Title level={5}>Document extraction</Typography.Title><Typography.Text type="secondary">Use Quizzer’s local PDF/text pipeline or an installed extractor plugin.</Typography.Text></div>
@@ -614,7 +617,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
           </div>
           <Select aria-label="Dense embedding component" value={embedderPlugin} onChange={setEmbedderPlugin} style={{ width: '100%' }}
             options={[
-              { value: 'builtin', label: `Built-in · Ollama ${status?.embeddings.model ?? 'profile model'}` },
+              { value: 'builtin', label: `Built-in · Ollama ${status?.embeddings?.model ?? 'profile model'}` },
               ...embedderPlugins.map(plugin => ({ value: plugin.id, label: `${plugin.name ?? plugin.id} · ${plugin.id}` })),
             ]} />
           {interfaceMode === 'advanced' && <>
@@ -629,7 +632,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
           </>}
           {embedderPlugin === 'builtin' && !status?.embeddings?.installed && !embeddingsWorking && <Button icon={<CloudDownloadOutlined />}
             onClick={installEmbeddingModel}>
-            {status?.embeddings?.runtimeInstalled ? `Download ${status.embeddings.model}` : `Install Ollama + ${status?.embeddings.model ?? 'embedding model'}`}
+            {status?.embeddings?.runtimeInstalled ? `Download ${status.embeddings.model}` : `Install Ollama + ${status?.embeddings?.model ?? 'embedding model'}`}
           </Button>}
           {embeddingReady && <Space><Switch aria-label="Enable dense embeddings" checked={enabledTools.embeddings} onChange={value => setEnabledTools(current => ({ ...current, embeddings: value }))} /><Typography.Text>Enabled</Typography.Text></Space>}
           {embedderPlugin === 'builtin' && embeddingsWorking && <Space><Spin size="small" /> Installing semantic filter…</Space>}
@@ -704,8 +707,8 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         <Divider orientation="left" plain>Signed-in agents</Divider>
         {AGENT_PROVIDERS.map(provider => {
           const agent = status?.[provider.id];
-          const working = agent?.job.state === 'working';
-          const loginUrl = agent?.job.message.match(/https:\/\/[^\s]+/)?.[0];
+          const working = agent?.job?.state === 'working';
+          const loginUrl = agent?.job?.message.match(/https:\/\/[^\s]+/)?.[0];
           return <section className="plugin-card" key={provider.id}>
             <div className="plugin-card-heading">
               <div><Typography.Title level={5}>{provider.label.replace(' – ', ' ')}</Typography.Title><Typography.Text type="secondary">{provider.description} No API key is required.</Typography.Text></div>
@@ -719,8 +722,11 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
                 {working && <Space><Spin size="small" /> Working…</Space>}
                 {agent?.connected && <Space><Switch aria-label={`Enable ${provider.label.replace(' – ', ' ')}`} checked={enabledProviders[provider.id]} onChange={value => setEnabledProviders(current => ({ ...current, [provider.id]: value }))} /><Typography.Text>Enabled</Typography.Text></Space>}
               </Space>
+              {provider.id === 'codex' && !agent?.installed && !working && <Alert type="warning" showIcon message="Codex CLI was not found"
+                description="Quizzer checks common user install locations as well as your inherited PATH. Install Codex or restart Quizzer after changing its location."
+                action={<Button size="small" icon={<ReloadOutlined />} onClick={() => void refresh()}>Detect again</Button>} />}
               {loginUrl && working && <Typography.Link href={loginUrl} target="_blank" rel="noreferrer">Open the sign-in page</Typography.Link>}
-              {agent?.job.message && agent.job.state !== 'idle' && <pre className="plugin-output">{agent.job.message}</pre>}
+              {agent?.job?.message && agent.job.state !== 'idle' && <pre className="plugin-output">{agent.job.message}</pre>}
             </Space>
           </section>;
         })}
@@ -769,7 +775,18 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
           );
         })}
 
-        <Divider orientation="left" plain>External plugins</Divider>
+        {!!configuredProviderOptions.length && <div>
+          <Typography.Text strong>Default generation provider</Typography.Text>
+          <Select aria-label="Default generation provider" value={visibleDefaultProvider} onChange={(value: GenerationProvider) => setDefaultProvider(value)} style={{ display: 'block', width: '100%', marginTop: 8 }}
+            options={configuredProviderOptions.map(provider => ({ label: provider.label, value: provider.id }))} />
+        </div>}
+        {!configuredProviderOptions.length && <Typography.Text type="secondary">Connect a provider above to make it available for generation.</Typography.Text>}
+      </Space>,
+      }, {
+        key: 'plugins',
+        label: 'Plugins',
+        children: <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Typography.Title level={5}>External plugins</Typography.Title>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
           External plugins run out of process with declared permissions and verified file hashes. Signed registry plugins are trusted normally; unsigned local plugins require Advanced Developer Mode.
         </Typography.Paragraph>
@@ -929,14 +946,8 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
           );
         })}
 
-        <Divider style={{ margin: '4px 0' }} />
-        {!!configuredProviderOptions.length && <div>
-          <Typography.Text strong>Default generation provider</Typography.Text>
-          <Select aria-label="Default generation provider" value={visibleDefaultProvider} onChange={(value: GenerationProvider) => setDefaultProvider(value)} style={{ display: 'block', width: '100%', marginTop: 8 }}
-            options={configuredProviderOptions.map(provider => ({ label: provider.label, value: provider.id }))} />
-        </div>}
-        {!configuredProviderOptions.length && <Typography.Text type="secondary">Connect a provider above to make it available for generation.</Typography.Text>}
-      </Space>}
+      </Space>,
+      }]} />}
     </Modal>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -109,13 +109,20 @@ button, input, textarea, select { font: inherit; }
 .home-recent-list { display: grid; }
 .home-recent-list .ant-btn { height: auto; min-height: 42px; display: flex; align-items: center; justify-content: space-between; text-align: left; }
 .onboarding-drawer .ant-drawer-body { padding-top: 12px; }
-.onboarding-steps { max-height: 165px; margin-top: 14px; overflow: hidden; }
+.onboarding-steps { margin-top: 2px; }
 .onboarding-steps .ant-steps-item { padding-bottom: 4px !important; }
 .onboarding-steps .ant-steps-item-description { display: none; }
 .onboarding-footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .onboarding-choice-grid { width: 100%; display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
 .onboarding-choice-grid .ant-radio-button-wrapper { height: auto; min-height: 116px; padding: 18px; border: 1px solid var(--border) !important; border-radius: 10px !important; white-space: normal; }
 .onboarding-choice-grid .ant-radio-button-wrapper::before { display: none; }
+.onboarding-choice-grid .ant-radio-button-wrapper-checked {
+  border-color: #1677ff !important;
+  background: var(--selected);
+  box-shadow: inset 0 0 0 2px #1677ff !important;
+}
+.onboarding-choice-grid .ant-radio-button-wrapper-checked strong { color: #0958d9; }
+:root[data-theme="dark"] .onboarding-choice-grid .ant-radio-button-wrapper-checked strong { color: #91caff; }
 .onboarding-choice-grid strong, .onboarding-choice-grid span { display: block; }
 .onboarding-choice-grid span { margin-top: 8px; color: var(--text-muted); line-height: 1.45; }
 .onboarding-hero-icon { font-size: 38px; color: #1677ff; }

--- a/src/types/pdf-worker.d.ts
+++ b/src/types/pdf-worker.d.ts
@@ -1,5 +1,0 @@
-declare module 'pdfjs-dist/build/pdf.worker.min.mjs' {
-  const workerSrc: string;
-  export default workerSrc;
-}
-

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -1,7 +1,9 @@
 import * as pdfjsLib from 'pdfjs-dist';
+import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 
-// This is where the real magic happens:
-pdfjsLib.GlobalWorkerOptions.workerSrc = `/node_modules/pdfjs-dist/build/pdf.worker.min.mjs`;
+// Let Vite emit the worker next to the renderer bundle so custom protocols such
+// as quizzer:// can load a real worker without falling back to a dynamic import.
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
 
 export interface ExtractedPdf {
   content: string;

--- a/test/desktop-service-process.test.mjs
+++ b/test/desktop-service-process.test.mjs
@@ -1,7 +1,24 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import test from 'node:test';
-import { isValidServicePort, serviceRestartDelay, waitForServiceReady } from '../desktop/service-process.mjs';
+import { executableSearchPath, isValidServicePort, serviceRestartDelay, waitForServiceReady } from '../desktop/service-process.mjs';
+
+test('adds common user CLI install locations without replacing the inherited path', () => {
+  const posix = executableSearchPath({ PATH: '/usr/bin:/bin' }, { platform: 'darwin', homeDirectory: '/Users/learner' }).split(':');
+  assert.deepEqual(posix.slice(0, 2), ['/usr/bin', '/bin']);
+  assert.ok(posix.includes('/Users/learner/.local/bin'));
+  assert.ok(posix.includes('/Users/learner/.volta/bin'));
+  assert.ok(posix.includes('/opt/homebrew/bin'));
+  assert.equal(posix.filter(entry => entry === '/usr/local/bin').length, 1);
+
+  const windows = executableSearchPath({
+    Path: 'C:\\Windows\\System32',
+    APPDATA: 'C:\\Users\\learner\\AppData\\Roaming',
+    LOCALAPPDATA: 'C:\\Users\\learner\\AppData\\Local',
+  }, { platform: 'win32', homeDirectory: 'C:\\Users\\learner' }).split(';');
+  assert.ok(windows.some(entry => entry.endsWith('AppData\\Roaming/npm')));
+  assert.ok(windows.some(entry => entry.endsWith('Microsoft/WinGet/Links')));
+});
 
 test('accepts only usable loopback service ports', () => {
   assert.equal(isValidServicePort(1), true);

--- a/test/desktop-service-process.test.mjs
+++ b/test/desktop-service-process.test.mjs
@@ -18,6 +18,22 @@ test('adds common user CLI install locations without replacing the inherited pat
   }, { platform: 'win32', homeDirectory: 'C:\\Users\\learner' }).split(';');
   assert.ok(windows.some(entry => entry.endsWith('AppData\\Roaming/npm')));
   assert.ok(windows.some(entry => entry.endsWith('Microsoft/WinGet/Links')));
+
+  const linux = executableSearchPath({
+    PATH: '/usr/local/bin:/usr/bin',
+    HOME: '/home/learner',
+  }, { platform: 'linux' }).split(':');
+  assert.ok(linux.includes('/home/learner/.cargo/bin'));
+  assert.equal(linux.filter(entry => entry === '/usr/local/bin').length, 1);
+  assert.equal(linux.includes('/opt/homebrew/bin'), false);
+
+  const minimalWindows = executableSearchPath({
+    PATH: 'C:\\Tools;C:\\TOOLS',
+    USERPROFILE: 'C:\\Users\\learner',
+  }, { platform: 'win32' }).split(';');
+  assert.deepEqual(minimalWindows, ['C:\\Tools']);
+
+  assert.equal(executableSearchPath({}, { platform: 'linux', homeDirectory: '' }), '/usr/local/bin');
 });
 
 test('accepts only usable loopback service ports', () => {


### PR DESCRIPTION
Closes #10

## Summary
- show only previous/current/next onboarding milestones and make selections visibly persistent
- default to the recommended hardware profile without a redundant action
- suspend walkthrough overlays while setup modals are open
- split Models and Plugins navigation and improve CLI discovery from desktop launches
- use the versioned llama.cpp settings endpoint
- remove the extractor chooser from import and use the configured extractor automatically
- bundle the PDF.js worker as a real renderer asset for packaged quizzer:// builds

## Verification
- npm test (387 tests)
- npm run lint
- npm run build
- npx playwright test e2e/onboarding.spec.ts --project=chromium
- verified exactly one emitted pdf.worker.min-*.mjs asset