### PR TITLE
Keep Activity focused on job monitoring

### DIFF
--- a/e2e/activity.spec.ts
+++ b/e2e/activity.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+import { dismissOnboarding } from './helpers';
+
+test('activity is a monitoring-only view', async ({ page }) => {
+  await dismissOnboarding(page);
+  await page.getByRole('button', { name: 'View activity' }).click();
+
+  const activity = page.getByRole('dialog', { name: 'Activity' });
+  await expect(activity).toBeVisible();
+  await expect(activity.getByRole('heading', { name: 'Quiz generation' })).toBeVisible();
+  await expect(activity.getByRole('heading', { name: 'Document indexing' })).toBeVisible();
+  await expect(activity.getByRole('slider')).toHaveCount(0);
+  await expect(activity.getByText('Background work survives reloads and connection interruptions')).toHaveCount(0);
+});

--- a/src/components/GenerationCenter.tsx
+++ b/src/components/GenerationCenter.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Alert, Badge, Button, Checkbox, Empty, Input, InputNumber, List, Modal, Progress, Select, Slider, Space, Tag, Typography } from 'antd';
+import { Alert, Badge, Button, Checkbox, Empty, Input, InputNumber, List, Modal, Progress, Select, Space, Tag, Typography } from 'antd';
 import { CloseOutlined, DatabaseOutlined, LoadingOutlined, PlayCircleOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db, type StoredGenerationJob, type StoredIndexJob } from '../db/db';
 import type { GenerationProvider } from '../types';
 import {
-  cancelGenerationJob, pumpGenerationQueue, removeGenerationJob, resumeGenerationJob, retryGenerationJob,
+  cancelGenerationJob, removeGenerationJob, resumeGenerationJob, retryGenerationJob,
 } from '../utils/generationQueue';
-import {
-  getGenerationBatchSize, getGenerationConcurrency, setGenerationBatchSize, setGenerationConcurrency,
-} from '../utils/generationSettings';
 import { getProviderDefinition, getProviderRoute, getProviderSettings } from '../utils/providerSettings';
 import { getMessageApi } from '../utils/messageProvider';
 import { useConfiguredProviders } from '../utils/useConfiguredProviders';
@@ -354,21 +351,6 @@ interface CenterProps { open: boolean; onClose: () => void; onOpenTest: (id: str
 export function GenerationCenter({ open, onClose, onOpenTest, onManagePlugins }: CenterProps) {
   const jobs = useLiveQuery(() => db.generationJobs.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const indexJobs = useLiveQuery(() => db.indexJobs.orderBy('createdAt').reverse().toArray(), []) ?? [];
-  const [instances, setInstances] = useState(getGenerationConcurrency);
-  const [batchSize, setBatchSize] = useState(getGenerationBatchSize);
-  const message = getMessageApi();
-  useEffect(() => {
-    const refresh = () => {
-      setInstances(getGenerationConcurrency());
-      setBatchSize(getGenerationBatchSize());
-    };
-    window.addEventListener('quizzer:generation-settings', refresh);
-    return () => window.removeEventListener('quizzer:generation-settings', refresh);
-  }, []);
-  const persistSetting = async (key: 'generation.concurrency' | 'generation.batchSize', value: number) => {
-    try { await serviceJson('/api/v1/settings', 'PATCH', { values: { [key]: value } }); }
-    catch (error) { message.warning(error instanceof Error ? error.message : 'The setting is saved locally until the service reconnects'); }
-  };
   const clearFinished = async () => Promise.all([
     db.generationJobs.bulkDelete(jobs.filter(job => terminalStatuses.has(job.status)).map(job => job.id)),
     db.indexJobs.bulkDelete(indexJobs.filter(job => terminalStatuses.has(job.status)).map(job => job.id)),
@@ -376,21 +358,7 @@ export function GenerationCenter({ open, onClose, onOpenTest, onManagePlugins }:
   const hasFinished = jobs.some(job => terminalStatuses.has(job.status)) || indexJobs.some(job => terminalStatuses.has(job.status));
   return <Modal open={open} width={780} title="Activity" footer={null} onCancel={onClose}>
     <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-      <Alert type="info" showIcon message="Background work survives reloads and connection interruptions"
-        description="Indexing checkpoints each document. Quiz generation stores every accepted question, so either workflow can continue from its last committed result." />
       <Typography.Title level={5} style={{ margin: 0 }}>Quiz generation</Typography.Title>
-      <div className="generation-concurrency">
-        <div><Typography.Text strong>Concurrent test instances</Typography.Text><br /><Typography.Text type="secondary">One provider request per test. Changes apply as running requests finish.</Typography.Text></div>
-        <Slider ariaLabelForHandle="Concurrent test instances" min={1} max={10} value={instances} marks={{ 1: '1', 5: '5', 10: '10' }} tooltip={{ formatter: value => `${value} instance${value === 1 ? '' : 's'}` }}
-          onChange={value => { setInstances(value); setGenerationConcurrency(value); void pumpGenerationQueue(); }}
-          onChangeComplete={value => void persistSetting('generation.concurrency', value)} />
-      </div>
-      <div className="generation-concurrency">
-        <div><Typography.Text strong>Questions per request</Typography.Text><br /><Typography.Text type="secondary">Larger batches are faster; smaller batches checkpoint more often.</Typography.Text></div>
-        <Slider ariaLabelForHandle="Questions per request" min={5} max={25} value={batchSize} marks={{ 5: '5', 10: '10', 20: '20', 25: '25' }} tooltip={{ formatter: value => `${value} questions` }}
-          onChange={value => { setBatchSize(value); setGenerationBatchSize(value); }}
-          onChangeComplete={value => void persistSetting('generation.batchSize', value)} />
-      </div>
       {hasFinished && <Button size="small" onClick={() => void clearFinished()}>Clear finished</Button>}
       <List locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No generation jobs" /> }} dataSource={jobs}
         renderItem={job => <JobItem job={job} onOpenTest={id => { onOpenTest(id); onClose(); }} onManagePlugins={onManagePlugins} />} />

--- a/src/index.css
+++ b/src/index.css
@@ -91,7 +91,6 @@ button, input, textarea, select { font: inherit; }
 .generation-job { padding: 16px !important; margin-bottom: 10px; border: 1px solid var(--border) !important; border-radius: 10px; background: var(--surface-soft); }
 .generation-job-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .generation-cost-summary { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
-.generation-concurrency { display: grid; grid-template-columns: minmax(220px, 1fr) minmax(220px, 320px); align-items: center; gap: 24px; padding: 14px 16px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-soft); }
 
 .mobile-header {
   position: fixed; inset: 0 0 auto 0; height: 56px; padding: 0 12px;
@@ -323,7 +322,6 @@ mark { color: #111827; }
   .question-count-grid { grid-template-columns: 1fr 1fr; }
   .generation-progress-heading { align-items: stretch; flex-direction: column; }
   .generation-activity { right: 12px; bottom: 12px; max-width: calc(100vw - 24px); }
-  .generation-concurrency { grid-template-columns: 1fr; gap: 8px; }
 }
 
 @media (max-width: 420px) {


### PR DESCRIPTION
Closes #12

## Summary
- remove the redundant Activity information banner
- remove generation concurrency and batch-size controls from the monitoring modal
- retain job monitoring, recovery, and cleanup actions

## Verification
- npm test (388 passed)
- npm run lint
- npm run build
- npx playwright test e2e/activity.spec.ts --project=chromium