### PR TITLE
Make Simple mode genuinely simple

### DIFF
--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -9,10 +9,10 @@ test('exposes semantic main navigation and keyboard-accessible mode control afte
   const navigation = page.locator('.desktop-sidebar');
   await expect(navigation).toBeVisible();
   const navigationItems = [
-    navigation.getByRole('button', { name: 'Home', exact: true }),
-    navigation.getByRole('tab', { name: 'Documents', exact: true }),
-    navigation.getByRole('tab', { name: 'Tests', exact: true }),
-    navigation.getByRole('button', { name: 'Activity', exact: true }),
+    navigation.locator('button').filter({ hasText: 'Home' }),
+    navigation.locator('[role="tab"]').filter({ hasText: 'Documents' }),
+    navigation.locator('[role="tab"]').filter({ hasText: 'Tests' }),
+    navigation.locator('button').filter({ hasText: 'Activity' }),
   ];
   for (const item of navigationItems) {
     await expect(item).toBeVisible();

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -1,16 +1,20 @@
 import { expect, test } from '@playwright/test';
+import { dismissOnboarding } from './helpers';
 
-test('boots with semantic main navigation and keyboard-accessible mode control', async ({ page }) => {
-  await page.goto('/');
+test('exposes semantic main navigation and keyboard-accessible mode control after onboarding', async ({ page }) => {
+  await dismissOnboarding(page);
   const shell = page.locator('.app-shell');
   await expect(shell).toBeVisible({ timeout: 15_000 });
 
   const navigation = page.locator('.desktop-sidebar');
   await expect(navigation).toBeVisible();
-  for (const name of ['Home', 'Documents', 'Tests', 'Activity']) {
-    const item = ['Documents', 'Tests'].includes(name)
-      ? navigation.locator('[role="tab"]').filter({ hasText: name })
-      : navigation.locator('button').filter({ hasText: name });
+  const navigationItems = [
+    navigation.getByRole('button', { name: 'Home', exact: true }),
+    navigation.getByRole('tab', { name: 'Documents', exact: true }),
+    navigation.getByRole('tab', { name: 'Tests', exact: true }),
+    navigation.getByRole('button', { name: 'Activity', exact: true }),
+  ];
+  for (const item of navigationItems) {
     await expect(item).toBeVisible();
     await item.focus();
     await expect(item).toBeFocused();

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -210,16 +210,18 @@ test('resumes real onboarding and finishes through durable quiz practice', async
 
   simulateQuota = true;
   await page.getByRole('button', { name: 'Create test' }).last().click();
-  await page.locator('.ant-modal input.ant-input').first().fill('Quota recovery quiz');
-  await page.getByText('coordination', { exact: true }).click();
-  await page.getByText('Balanced learning · 20 questions').click();
-  await page.getByText('Quick review · 10 questions').click();
-  await expect(page.getByRole('button', { name: 'Queue combined test' })).toBeDisabled();
-  await page.getByRole('checkbox', { name: /I approve sending selected excerpts/ }).check();
-  await page.getByRole('button', { name: 'Queue combined test' }).click();
+  const recoveryDialog = page.locator('.ant-modal-content').filter({ hasText: 'Create tests from documents' });
+  await recoveryDialog.getByRole('checkbox', { name: 'Select coordination' }).check();
+  const recoveryQuizLength = recoveryDialog.getByRole('combobox', { name: 'Quiz length' });
+  await recoveryQuizLength.focus();
+  await recoveryQuizLength.press('ArrowDown');
+  await page.locator('.ant-select-dropdown:visible').getByText('Quick · 10 questions').click();
+  await expect(recoveryDialog.getByRole('button', { name: 'Create test' })).toBeDisabled();
+  await recoveryDialog.getByRole('checkbox', { name: 'Allow Quizzer to send these excerpts for this test.' }).check();
+  await recoveryDialog.getByRole('button', { name: 'Create test' }).click();
 
   await page.getByRole('button', { name: /need attention/ }).click();
-  const recoveryJob = page.locator('.generation-job').filter({ hasText: 'Quota recovery quiz' });
+  const recoveryJob = page.locator('.generation-job').filter({ hasText: 'coordination quiz (2)' });
   await expect(recoveryJob.getByText('paused', { exact: true })).toBeVisible({ timeout: 60_000 });
   await expect(recoveryJob.getByText('8/10', { exact: true })).toBeVisible();
   await expect(recoveryJob.getByText('Quota exhausted for this route')).toBeVisible();

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -151,21 +151,25 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await expect(page.getByRole('radio', { name: 'Simple', exact: true })).toBeChecked();
   await expect(page.getByRole('button', { name: 'Continue' })).toBeDisabled();
   await page.locator('.onboarding-drawer').getByRole('button').filter({ hasText: 'Create test' }).click();
-  await page.getByText('coordination', { exact: true }).click();
-  await page.getByText('Balanced learning · 20 questions').click();
-  await page.getByText('Quick review · 10 questions').click();
-  await expect(page.getByRole('button', { name: 'Queue combined test' })).toBeDisabled();
-  await page.getByRole('checkbox', { name: /I approve sending selected excerpts/ }).check();
-  await page.getByRole('button', { name: 'Queue combined test' }).click();
+  const creationDialog = page.locator('.ant-modal-content').filter({ hasText: 'Create tests from documents' });
+  await creationDialog.getByRole('checkbox', { name: 'Select coordination' }).check();
+  const quizLength = creationDialog.getByRole('combobox', { name: 'Quiz length' });
+  await quizLength.focus();
+  await quizLength.press('ArrowDown');
+  await page.locator('.ant-select-dropdown:visible').getByText('Quick · 10 questions').click();
+  await expect(creationDialog.getByRole('textbox', { name: 'Learning goal' })).toHaveValue('Focus on safe concurrent updates.');
+  await expect(creationDialog.getByRole('button', { name: 'Create test' })).toBeDisabled();
+  await creationDialog.getByRole('checkbox', { name: 'Allow Quizzer to send these excerpts for this test.' }).check();
+  await creationDialog.getByRole('button', { name: 'Create test' }).click();
 
   await expect(page.getByText('Your quiz is being generated')).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText('Combined quiz is ready')).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText('coordination quiz is ready')).toBeVisible({ timeout: 60_000 });
   await expect(page.getByText('10 validated questions')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Continue' })).toBeEnabled();
   await page.getByRole('button', { name: 'Continue' }).click();
 
   await expect(page.getByRole('heading', { name: 'Try one question' })).toBeVisible();
-  await page.getByRole('button', { name: 'Open Combined quiz' }).click();
+  await page.getByRole('button', { name: 'Open coordination quiz' }).click();
   await page.locator('.ant-radio-button-wrapper').filter({ hasText: 'Practice mode' }).click();
   await page.getByRole('button', { name: 'Start Practice' }).click();
   await expect(page.getByRole('heading', { name: 'Question 1' })).toBeVisible();

--- a/e2e/simple-advanced.spec.ts
+++ b/e2e/simple-advanced.spec.ts
@@ -13,6 +13,7 @@ test('immediate reversible Simple/Advanced disclosure with stored data retained'
   const studioButton = page.getByRole('button', { name: 'Prompt Studio' });
   await expect(simpleToggle).toBeVisible();
   await expect(studioButton).toBeVisible();
+  await expect(page.getByText('System health', { exact: true })).toBeVisible();
 
   await studioButton.click();
   await page.getByRole('button', { name: 'Clone selected' }).click();
@@ -25,6 +26,7 @@ test('immediate reversible Simple/Advanced disclosure with stored data retained'
   await simpleToggle.click();
   await expect(advancedToggle).toBeVisible();
   await expect(studioButton).toBeHidden();
+  await expect(page.getByText('System health', { exact: true })).toHaveCount(0);
 
   await page.reload();
   await dismissOnboarding(page, false);
@@ -103,4 +105,63 @@ test('Advanced creation submits explicit per-test generation and RAG overrides',
   });
   expect(options.ragProfile).toMatchObject({ contextBudget: 12_288, rerank: true, override: true });
   expect(options.ragProfile?.contextBudget).not.toBe(options.resolvedSettings?.['retrieval.contextBudget']);
+});
+
+test('Simple creation is a plain source, length, and learning-goal flow', async ({ page }) => {
+  let createdJobs: Array<{ name: string; options: Record<string, unknown> }> = [];
+  await page.route('**/api/integrations', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      codex: { installed: true, connected: true },
+      marker: { installed: false, job: { state: 'idle', message: '' } },
+    }),
+  }));
+  await page.route('**/api/v1/jobs', async route => {
+    if (route.request().method() === 'POST') {
+      const body = route.request().postDataJSON() as { jobs?: Array<{ name: string; options: Record<string, unknown> }> };
+      createdJobs = body.jobs ?? [];
+    }
+    await route.continue();
+  });
+
+  await dismissOnboarding(page);
+  await setInterfaceMode(page, 'simple');
+  await expect(page.getByText('System health', { exact: true })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Add documents' }).last().click();
+  await page.locator('input[type="file"]').setInputFiles({
+    name: 'lease-basics.md',
+    mimeType: 'text/markdown',
+    buffer: Buffer.from('# Lease safety\n\nA lease grants one writer exclusive access and must be released in a finally block.'),
+  });
+  await expect(page.getByText('ready', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Add to library' }).click();
+
+  await page.getByRole('button', { name: 'Create test' }).last().click();
+  const dialog = page.locator('.ant-modal-content').filter({ hasText: 'Create tests from documents' });
+  await expect(dialog.getByRole('heading', { name: '1. Choose your documents' })).toBeVisible();
+  await expect(dialog.getByRole('heading', { name: '2. Choose a quiz length' })).toBeVisible();
+  await expect(dialog.getByRole('heading', { name: /3. Add a learning goal/ })).toBeVisible();
+  await expect(dialog.getByText('Generation runs in the background')).toHaveCount(0);
+  await expect(dialog.getByText('One combined test')).toHaveCount(0);
+  await expect(dialog.getByText('Prompt profile')).toHaveCount(0);
+  await expect(dialog.getByText('Rerank retrieved evidence')).toHaveCount(0);
+
+  await dialog.getByRole('checkbox', { name: 'Select lease-basics' }).check();
+  const quizLength = dialog.getByRole('combobox', { name: 'Quiz length' });
+  await quizLength.focus();
+  await quizLength.press('ArrowDown');
+  await page.locator('.ant-select-dropdown:visible').getByText('Quick · 10 questions').click();
+  await dialog.getByRole('textbox', { name: 'Learning goal' }).fill('Focus on safe cleanup.');
+  await dialog.getByRole('checkbox', { name: 'Allow Quizzer to send these excerpts for this test.' }).check();
+  await dialog.getByRole('button', { name: 'Create test' }).click();
+
+  await expect.poll(() => createdJobs.length).toBe(1);
+  expect(createdJobs[0].name).toBe('lease-basics quiz');
+  expect(createdJobs[0].options).toMatchObject({
+    questionCount: 10,
+    questionCounts: { multipleChoice: 8, fillBlank: 1, reasoning: 1, coding: 0 },
+    coverageStrategy: 'balanced',
+    customInstruction: 'Focus on safe cleanup.',
+  });
+  expect(createdJobs[0].options.generationProfile).toBeUndefined();
 });

--- a/src/components/AddTestModal.tsx
+++ b/src/components/AddTestModal.tsx
@@ -25,9 +25,9 @@ type QuizPreset = 'quick' | 'balanced' | 'deep';
 type ResolvedSettings = { profile: string; values: Record<string, string | number | boolean> };
 
 const presets: Record<QuizPreset, { label: string; description: string; counts: [number, number, number, number] }> = {
-  quick: { label: 'Quick review · 10 questions', description: 'Fast recall with a small reasoning check.', counts: [8, 1, 1, 0] },
-  balanced: { label: 'Balanced learning · 20 questions', description: 'A practical mix of recall and explanation.', counts: [15, 3, 2, 0] },
-  deep: { label: 'Deep practice · 30 questions', description: 'More reasoning, fill-in, and coding practice.', counts: [18, 6, 4, 2] },
+  quick: { label: 'Quick · 10 questions', description: 'A short review of the most important ideas.', counts: [8, 1, 1, 0] },
+  balanced: { label: 'Standard · 20 questions', description: 'A balanced quiz for learning and recall.', counts: [15, 3, 2, 0] },
+  deep: { label: 'Thorough · 30 questions', description: 'Broader practice with more written and coding questions.', counts: [18, 6, 4, 2] },
 };
 
 const hardwareDefaults: Record<StoredAppProfile['hardwareProfile'], { contextBudget: number; rerank: boolean; batchSize: number }> = {
@@ -79,7 +79,12 @@ export default function AddTestModal({ onClose, onManagePlugins, onOpenPromptStu
   const [query, setQuery] = useState('');
   const [saving, setSaving] = useState(false);
   const message = getMessageApi();
-  const questionCount = multipleChoiceCount + fillBlankCount + reasoningCount + codingCount;
+  const simple = profile.interfaceMode === 'simple';
+  const [presetMultipleChoice, presetFillBlank, presetReasoning, presetCoding] = presets[preset].counts;
+  const effectiveCounts = simple
+    ? { multipleChoice: presetMultipleChoice, fillBlank: presetFillBlank, reasoning: presetReasoning, coding: presetCoding }
+    : { multipleChoice: multipleChoiceCount, fillBlank: fillBlankCount, reasoning: reasoningCount, coding: codingCount };
+  const questionCount = effectiveCounts.multipleChoice + effectiveCounts.fillBlank + effectiveCounts.reasoning + effectiveCounts.coding;
   const selectedProvider = getProviderDefinition(provider);
   const promptProfiles = [BUILT_IN_PROMPT_PROFILE, ...customPromptProfiles];
   const promptProfile = promptProfiles.find(item => item.id === promptProfileId) ?? BUILT_IN_PROMPT_PROFILE;
@@ -113,14 +118,15 @@ export default function AddTestModal({ onClose, onManagePlugins, onOpenPromptStu
 
   const toggle = (id: string) => setSelectedIds(ids => ids.includes(id) ? ids.filter(item => item !== id) : [...ids, id]);
 
-  const applyPreset = (next: QuizPreset) => {
-    setPreset(next);
-    const [multipleChoice, fillBlank, reasoning, coding] = presets[next].counts;
-    setMultipleChoiceCount(multipleChoice);
-    setFillBlankCount(fillBlank);
-    setReasoningCount(reasoning);
-    setCodingCount(coding);
-  };
+  const documentPicker = <>
+    {documents.length > 6 && <Input.Search aria-label="Find documents" value={query} onChange={event => setQuery(event.target.value)} placeholder="Find documents" />}
+    <List bordered size="small" style={{ maxHeight: 290, overflowY: 'auto' }} dataSource={visible}
+      renderItem={document => <List.Item onClick={() => toggle(document.id)} style={{ cursor: 'pointer' }}>
+        <Checkbox aria-label={`Select ${document.name}`} checked={selectedIds.includes(document.id)} style={{ marginRight: 12 }} />
+        <List.Item.Meta title={document.name} description={document.tags.map(tag => <Tag key={tag}>{tag}</Tag>)} />
+      </List.Item>} />
+    <Typography.Text type="secondary">{selected.length} document{selected.length === 1 ? '' : 's'} selected</Typography.Text>
+  </>;
 
   const resetAdvancedControls = () => {
     const defaults = hardwareDefaults[profile.hardwareProfile];
@@ -156,7 +162,7 @@ export default function AddTestModal({ onClose, onManagePlugins, onOpenPromptStu
         && (contextBudget !== resolvedContextBudget || rerank !== resolvedRerank);
       const options: GenerationOptions = {
         provider, model: model.trim() || undefined, questionCount,
-        questionCounts: { multipleChoice: multipleChoiceCount, fillBlank: fillBlankCount, reasoning: reasoningCount, coding: codingCount },
+        questionCounts: effectiveCounts,
         multipleChoiceMode,
         coverageStrategy: mode === 'combined' ? coverageStrategy : 'balanced',
         customInstruction: customInstruction.trim() || undefined,
@@ -175,8 +181,13 @@ export default function AddTestModal({ onClose, onManagePlugins, onOpenPromptStu
           ? { costCeilingMicroUsd: Math.round(costCeilingDollars * 1_000_000) }
           : {}),
       };
-      const requestedSources = mode === 'combined'
-        ? [{ name: name.trim() || 'Combined quiz', documentIds: selected.map(document => document.id) }]
+      const requestedSources = simple
+        ? [{
+          name: selected.length === 1 ? `${selected[0].name} quiz` : `Quiz from ${selected.length} documents`,
+          documentIds: selected.map(document => document.id),
+        }]
+        : mode === 'combined'
+          ? [{ name: name.trim() || 'Combined quiz', documentIds: selected.map(document => document.id) }]
         : selected.map(document => ({ name: document.name, documentIds: [document.id] }));
       const [savedTests, existingJobs] = await Promise.all([db.tests.toArray(), db.generationJobs.toArray()]);
       const usedNames = new Set([
@@ -203,20 +214,21 @@ export default function AddTestModal({ onClose, onManagePlugins, onOpenPromptStu
   };
 
   return (
-    <Modal open width={760} title="Create tests from documents" onCancel={onClose} footer={(_, { CancelBtn }) => <>
+    <Modal open width={760} title="Create tests from documents" onCancel={onClose}
+      styles={{ body: { maxHeight: 'calc(100vh - 190px)', overflowY: 'auto' } }} footer={(_, { CancelBtn }) => <>
       {!saving && <CancelBtn />}
       {saving ? <Space><Spin size="small" /> Queueing tests…</Space>
         : selected.length > 0 && questionCount >= 1 && questionCount <= 200 && configured.providers.length > 0
-          ? <Button type="primary" disabled={!routesApproved} onClick={() => void create()}>{mode === 'combined' ? 'Queue combined test' : `Queue ${selected.length} separate test(s)`}</Button>
+          ? <Button type="primary" disabled={!routesApproved} onClick={() => void create()}>{simple ? 'Create test' : mode === 'combined' ? 'Queue combined test' : `Queue ${selected.length} separate test(s)`}</Button>
           : null}
     </>}>
       {!documents.length ? <Empty description="Add documents to your library before creating a test" /> : (
         <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-          <Alert type="info" showIcon message="Generation runs in the background"
-            description="Completed tests appear immediately. Each configured instance works on a different test, while batches within a test run sequentially to reduce duplicates." />
-          <Radio.Group value={mode} onChange={event => setMode(event.target.value)} optionType="button" buttonStyle="solid"
-            options={[{ label: 'One combined test', value: 'combined' }, { label: 'Separate test per document', value: 'separate' }]} />
-          {mode === 'combined' && <Input value={name} onChange={event => setName(event.target.value)} addonBefore="Test name" />}
+          {!simple && <Alert type="info" showIcon message="Generation runs in the background"
+            description="Completed tests appear immediately. Each configured instance works on a different test, while batches within a test run sequentially to reduce duplicates." />}
+          {!simple && <Radio.Group value={mode} onChange={event => setMode(event.target.value)} optionType="button" buttonStyle="solid"
+            options={[{ label: 'One combined test', value: 'combined' }, { label: 'Separate test per document', value: 'separate' }]} />}
+          {!simple && mode === 'combined' && <Input value={name} onChange={event => setName(event.target.value)} addonBefore="Test name" />}
           {configured.loading && !configured.providers.length && <Space><Spin size="small" /><Typography.Text type="secondary">Checking connected providers…</Typography.Text></Space>}
           {!configured.loading && !configured.providers.length && <Alert type="warning" showIcon message="No AI provider is configured"
             description="Connect a CLI agent or add an API key before creating a test."
@@ -262,12 +274,23 @@ export default function AddTestModal({ onClose, onManagePlugins, onOpenPromptStu
               Quizzer does not guess prices for unknown models. Enter the provider’s current input and output rates before using a finite ceiling; the values are snapshotted into this test.
             </Typography.Paragraph>
           </div>}
-          {profile.interfaceMode === 'simple' && <div>
-            <Typography.Text strong>Recommended preset</Typography.Text>
-            <Select value={preset} onChange={applyPreset} style={{ width: '100%', marginTop: 8 }} options={Object.entries(presets).map(([value, item]) => ({ value, label: item.label }))} />
-            <Typography.Paragraph type="secondary" style={{ margin: '6px 0 0' }}>{presets[preset].description}</Typography.Paragraph>
+          {simple && <div className="simple-test-flow">
+            <section>
+              <Typography.Title level={5}>1. Choose your documents</Typography.Title>
+              {documentPicker}
+            </section>
+            <section>
+              <Typography.Title level={5}>2. Choose a quiz length</Typography.Title>
+              <Select aria-label="Quiz length" value={preset} onChange={setPreset} style={{ width: '100%' }} options={Object.entries(presets).map(([value, item]) => ({ value, label: item.label }))} />
+              <Typography.Paragraph type="secondary" style={{ margin: '6px 0 0' }}>{presets[preset].description}</Typography.Paragraph>
+            </section>
+            <section>
+              <Typography.Title level={5}>3. Add a learning goal <Typography.Text type="secondary">(optional)</Typography.Text></Typography.Title>
+              <Input.TextArea aria-label="Learning goal" data-onboarding-target="learning-instruction" rows={3} maxLength={2000} value={customInstruction} onChange={event => setCustomInstruction(event.target.value)}
+                placeholder="For example: Focus on the ideas I am most likely to forget" />
+            </section>
           </div>}
-          {profile.interfaceMode === 'advanced' && <div className="question-count-grid">
+          {!simple && profile.interfaceMode === 'advanced' && <div className="question-count-grid">
             <label><Typography.Text strong>Multiple choice</Typography.Text><InputNumber min={0} max={200} value={multipleChoiceCount} onChange={value => setMultipleChoiceCount(value ?? 0)} /></label>
             <label><Typography.Text strong>Fill in the blank</Typography.Text><InputNumber min={0} max={200} value={fillBlankCount} onChange={value => setFillBlankCount(value ?? 0)} /></label>
             <label><Typography.Text strong>Reasoning</Typography.Text><InputNumber min={0} max={200} value={reasoningCount} onChange={value => setReasoningCount(value ?? 0)} /></label>
@@ -327,19 +350,30 @@ export default function AddTestModal({ onClose, onManagePlugins, onOpenPromptStu
               Quizzer sends only the assigned page-aware chunks for each batch, keeping large combined tests within a fixed prompt budget.
             </Typography.Paragraph>
           </div>}
-          {mode === 'combined' && selected.length > questionCount && questionCount > 0 && <Alert type="warning" showIcon
+          {!simple && mode === 'combined' && selected.length > questionCount && questionCount > 0 && <Alert type="warning" showIcon
             message={`${questionCount} questions cannot represent all ${selected.length} documents`}
             description={coverageStrategy === 'ai-selected'
               ? 'AI-selected coverage will prioritize the most central material. Increase the question count if every document must appear.'
               : 'Quizzer will sample across the selection. Increase the question count to guarantee at least one question per document.'} />}
           {questionCount < 1 && <Alert type="error" showIcon message="Choose at least one question." />}
           {questionCount > 200 && <Alert type="error" showIcon message="A test can contain at most 200 questions." />}
-          <div>
+          {!simple && <div>
             <Typography.Text strong>Custom learning instruction <Typography.Text type="secondary">(optional)</Typography.Text></Typography.Text>
             <Input.TextArea data-onboarding-target="learning-instruction" rows={3} maxLength={2000} showCount value={customInstruction} onChange={event => setCustomInstruction(event.target.value)}
               placeholder="For example: coding questions about Terraform only" style={{ marginTop: 8 }} />
-          </div>
-          {!!configured.providers.length && <Alert type={proposedRoutes.some(route => route.paid) ? 'warning' : 'info'} showIcon
+          </div>}
+          {!!configured.providers.length && simple && requiresRouteApproval && <Alert type={proposedRoutes.some(route => route.paid) ? 'warning' : 'info'} showIcon
+            message={`Use ${selectedProvider.label} for this test?`}
+            description={<Space direction="vertical" size="small">
+              <Typography.Text>
+                Quizzer will send only the relevant excerpts from your selected documents to {selectedProvider.label}{proposedRoutes.some(route => route.paid) ? '. Provider charges may apply.' : '.'}
+              </Typography.Text>
+              <Checkbox checked={routesApproved} onChange={event => setApprovedRouteSignature(event.target.checked ? routeSignature : '')}>
+                Allow Quizzer to send these excerpts for this test.
+              </Checkbox>
+              <Button type="link" size="small" onClick={onManagePlugins} style={{ padding: 0, alignSelf: 'flex-start' }}>Change AI</Button>
+            </Space>} />}
+          {!!configured.providers.length && !simple && <Alert type={proposedRoutes.some(route => route.paid) ? 'warning' : 'info'} showIcon
             message="Data-sharing & cost approval"
             description={<Space direction="vertical" size="small">
               <Typography.Text>Only selected source excerpts and relevant images are sent. Review every route before approving:</Typography.Text>
@@ -349,16 +383,9 @@ export default function AddTestModal({ onClose, onManagePlugins, onOpenPromptStu
               <Checkbox checked={routesApproved} onChange={event => setApprovedRouteSignature(event.target.checked ? routeSignature : '')}>
                 I approve sending selected excerpts and relevant images to these routes{proposedRoutes.some(route => route.paid) ? ' and understand usage charges may apply' : ''}.
               </Checkbox>
-              {profile.interfaceMode === 'simple' && <Button type="link" size="small" onClick={onManagePlugins}>Change AI</Button>}
             </Space>} />}
-          {!saving && <Typography.Text type="secondary">Provider defaults are saved in <Button type="link" size="small" onClick={onManagePlugins}>Plugins & models</Button>. You can override the model for this job.</Typography.Text>}
-          <Input.Search value={query} onChange={event => setQuery(event.target.value)} placeholder="Filter documents by name or tag" />
-          <List bordered size="small" style={{ maxHeight: 290, overflowY: 'auto' }} dataSource={visible}
-            renderItem={document => <List.Item onClick={() => toggle(document.id)} style={{ cursor: 'pointer' }}>
-              <Checkbox checked={selectedIds.includes(document.id)} style={{ marginRight: 12 }} />
-              <List.Item.Meta title={document.name} description={document.tags.map(tag => <Tag key={tag}>{tag}</Tag>)} />
-            </List.Item>} />
-          <Typography.Text type="secondary">{selected.length} document(s) selected</Typography.Text>
+          {!simple && !saving && <Typography.Text type="secondary">Provider defaults are saved in <Button type="link" size="small" onClick={onManagePlugins}>Plugins & models</Button>. You can override the model for this job.</Typography.Text>}
+          {!simple && documentPicker}
         </Space>
       )}
     </Modal>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -31,6 +31,7 @@ interface Props {
 
 export default function HomePage({ profile, onAddDocument, onAddTest, onOpenGeneration, onOpenPlugins, onOpenTest, onOpenTutorial }: Props) {
   const configured = useConfiguredProviders();
+  const advanced = profile.interfaceMode === 'advanced';
   const [systemHealth, setSystemHealth] = useState<{ index?: IndexHealth; plugins?: PluginHealth; error?: string; loading: boolean }>({ loading: true });
   const data = useLiveQuery(async () => {
     const [documents, testCount, tests, jobs, indexJobs, drafts] = await Promise.all([
@@ -62,10 +63,11 @@ export default function HomePage({ profile, onAddDocument, onAddTest, onOpenGene
     }
   }, []);
   useEffect(() => {
+    if (!advanced) return;
     void refreshHealth();
     const timer = window.setInterval(() => void refreshHealth(), 15_000);
     return () => window.clearInterval(timer);
-  }, [refreshHealth]);
+  }, [advanced, refreshHealth]);
 
   const pluginProblems = systemHealth.plugins?.plugins.filter(plugin => !plugin.compatible || plugin.status !== 'installed').length ?? 0;
   const healthRows = [
@@ -99,28 +101,28 @@ export default function HomePage({ profile, onAddDocument, onAddTest, onOpenGene
     </Card>}
 
     <Row gutter={[16, 16]}>
-      <Col xs={12} md={6}><Card><Statistic title="Documents" value={data?.documents ?? 0} prefix={<FileAddOutlined />} /></Card></Col>
-      <Col xs={12} md={6}><Card><Statistic title="Tests" value={data?.testCount ?? 0} prefix={<FormOutlined />} /></Card></Col>
-      <Col xs={12} md={6}><Card><Statistic title="Active jobs" value={activeJobCount} prefix={<SyncOutlined spin={hasRunningJob} />} /></Card></Col>
-      <Col xs={12} md={6}><Card><Statistic title="Profile" value={profile.hardwareProfile.toUpperCase()} prefix={<ApiOutlined />} /></Card></Col>
+      <Col xs={12} md={advanced ? 6 : 8}><Card><Statistic title="Documents" value={data?.documents ?? 0} prefix={<FileAddOutlined />} /></Card></Col>
+      <Col xs={12} md={advanced ? 6 : 8}><Card><Statistic title="Tests" value={data?.testCount ?? 0} prefix={<FormOutlined />} /></Card></Col>
+      <Col xs={12} md={advanced ? 6 : 8}><Card><Statistic title={advanced ? 'Active jobs' : 'In progress'} value={activeJobCount} prefix={<SyncOutlined spin={hasRunningJob} />} /></Card></Col>
+      {advanced && <Col xs={12} md={6}><Card><Statistic title="Profile" value={profile.hardwareProfile.toUpperCase()} prefix={<ApiOutlined />} /></Card></Col>}
     </Row>
 
     <Card title="Start here">
       <Space wrap>
         <Button data-onboarding-target="document" type="primary" icon={<FileAddOutlined />} onClick={onAddDocument}>Add documents</Button>
         <Button data-onboarding-target="create-test" icon={<FormOutlined />} onClick={onAddTest}>Create test</Button>
-        <Button data-onboarding-target="provider" icon={<ApiOutlined />} onClick={onOpenPlugins}>Configure AI</Button>
-        <Button icon={<SyncOutlined />} onClick={onOpenGeneration}>View activity</Button>
+        {(advanced || (!configured.loading && !configured.providers.length)) && <Button data-onboarding-target="provider" icon={<ApiOutlined />} onClick={onOpenPlugins}>Configure AI</Button>}
+        {(advanced || activeJobCount > 0) && <Button icon={<SyncOutlined />} onClick={onOpenGeneration}>View activity</Button>}
       </Space>
     </Card>
 
-    <Card title="System health" extra={<Button size="small" icon={<ReloadOutlined spin={systemHealth.loading} />} onClick={() => void refreshHealth()}>Refresh</Button>}>
+    {advanced && <Card title="System health" extra={<Button size="small" icon={<ReloadOutlined spin={systemHealth.loading} />} onClick={() => void refreshHealth()}>Refresh</Button>}>
       {systemHealth.error && <Alert type="error" showIcon message="Quizzer's local service could not be reached" description={systemHealth.error} style={{ marginBottom: 12 }} />}
       <List size="small" dataSource={healthRows} renderItem={item => <List.Item actions={item.label === 'AI routes' || item.label === 'Plugins'
         ? [<Button type="link" size="small" key="manage" onClick={onOpenPlugins}>Manage</Button>] : undefined}>
         <List.Item.Meta avatar={<span className="system-health-icon">{item.icon}</span>} title={<Space><Badge status={item.status} />{item.label}</Space>} description={item.detail} />
       </List.Item>} />
-    </Card>
+    </Card>}
 
     <Row gutter={[16, 16]}>
       <Col xs={24} lg={14}><Card title="Recent tests">

--- a/src/index.css
+++ b/src/index.css
@@ -94,6 +94,9 @@ button, input, textarea, select { font: inherit; }
 .question-count-grid .ant-input-number { width: 100%; }
 .question-count-total { align-items: center; justify-content: center; font-size: 18px; }
 .answer-mode-selector { display: inline-flex; flex-wrap: wrap; }
+.simple-test-flow { display: grid; gap: 18px; }
+.simple-test-flow section { display: grid; gap: 8px; }
+.simple-test-flow h5 { margin: 0; }
 .generation-progress { display: flex; flex-direction: column; gap: 10px; padding: 14px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-soft); }
 .generation-progress-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .generation-activity { position: fixed; right: 20px; bottom: 20px; z-index: 80; box-shadow: 0 8px 24px rgb(0 0 0 / 24%); }


### PR DESCRIPTION
Closes #15

## Summary
- simplify the basic dashboard and hide technical health/profile detail
- reduce Simple quiz creation to source, quiz length, and an optional learning goal
- retain plain-language provider consent while preserving all Advanced controls

## Verification
- npm test (388 passed)
- npm run lint
- npm run build
- npx playwright test e2e/simple-advanced.spec.ts --project=chromium (3 passed)