### PR TITLE
Organize settings into focused tabs

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -8,9 +8,24 @@ test('Settings search/reset and keyboard accessibility', async ({ page }) => {
   await page.keyboard.press(process.platform === 'darwin' ? 'Meta+,' : 'Control+,');
   const dialog = page.locator('.ant-modal-content').filter({ hasText: 'Settings' });
   await expect(dialog.getByText('Settings', { exact: true })).toBeVisible();
+  await expect(dialog.getByRole('tab', { name: 'Overall' })).toHaveAttribute('aria-selected', 'true');
+  await expect(dialog.getByRole('radiogroup', { name: 'Theme' })).toBeVisible();
+  await expect(dialog.locator('.settings-row').filter({ hasText: 'Interface mode' }).getByText('Advanced', { exact: true })).toBeVisible();
+  await expect(dialog.getByRole('combobox', { name: 'Hardware profile' })).toBeVisible();
+  await expect(dialog.getByText('Software Updates')).toBeVisible();
+
+  await dialog.getByText('Dark', { exact: true }).click();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('quizzer.theme'))).toBe('dark');
+
+  await dialog.getByRole('tab', { name: 'Retrieval' }).click();
+  await expect(dialog.getByRole('spinbutton', { name: 'Context budget' })).toBeVisible();
+  await dialog.getByRole('tab', { name: 'Documents' }).click();
+  await expect(dialog.getByRole('switch', { name: 'OCR' })).toBeVisible();
 
   const search = dialog.getByLabel('Search settings');
   await search.fill('Generation concurrency');
+  await expect(dialog.getByRole('tab', { name: 'Generation' })).toHaveAttribute('aria-selected', 'true');
   const concurrency = dialog.getByRole('spinbutton', { name: 'Generation concurrency' });
   await expect(concurrency).toBeVisible();
   await expect(dialog.getByText('Hardware profile', { exact: true })).toBeHidden();

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -28,12 +28,13 @@ test('Settings search/reset and keyboard accessibility', async ({ page }) => {
   await expect(dialog.getByRole('tab', { name: 'Generation' })).toHaveAttribute('aria-selected', 'true');
   const concurrency = dialog.getByRole('spinbutton', { name: 'Generation concurrency' });
   await expect(concurrency).toBeVisible();
+  const selectedProfileConcurrency = await concurrency.inputValue();
   await expect(dialog.getByText('Hardware profile', { exact: true })).toBeHidden();
 
   await concurrency.fill('7');
   await expect(dialog.getByRole('button', { name: 'Save changes' })).toBeEnabled();
   await dialog.getByRole('button', { name: 'Reset to selected profile' }).click();
-  await expect(concurrency).toHaveValue('1');
+  await expect(concurrency).toHaveValue(selectedProfileConcurrency);
 
   await dialog.getByRole('button', { name: 'Save changes' }).click();
   await expect(page.getByText('Settings saved')).toBeVisible();
@@ -41,5 +42,5 @@ test('Settings search/reset and keyboard accessibility', async ({ page }) => {
 
   await page.keyboard.press(process.platform === 'darwin' ? 'Meta+,' : 'Control+,');
   await dialog.getByLabel('Search settings').fill('Generation concurrency');
-  await expect(dialog.getByRole('spinbutton', { name: 'Generation concurrency' })).toHaveValue('1');
+  await expect(dialog.getByRole('spinbutton', { name: 'Generation concurrency' })).toHaveValue(selectedProfileConcurrency);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,9 @@ import OnboardingGuide from './components/OnboardingGuide';
 import { recordOnboardingDocument, recordOnboardingGeneration, restartOnboarding, setInterfaceMode } from './utils/appProfile';
 import { useRuntimeSettings } from './utils/useRuntimeSettings';
 
-interface ShellProps { dark: boolean; onToggleTheme: () => void; }
+interface ShellProps { dark: boolean; onToggleTheme: () => void; onThemeChange: (dark: boolean) => void; }
 
-function AppShell({ dark, onToggleTheme }: ShellProps) {
+function AppShell({ dark, onToggleTheme, onThemeChange }: ShellProps) {
   const [selection, setSelection] = useState<LibrarySelection>(null);
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDocumentModal, setShowDocumentModal] = useState(false);
@@ -153,7 +153,7 @@ function AppShell({ dark, onToggleTheme }: ShellProps) {
         setSelection({ kind: 'document', id }); setShowDocumentModal(false);
       }} />}
       {showPluginsModal && profile && <PluginsModal interfaceMode={profile.interfaceMode} onClose={() => setShowPluginsModal(false)} />}
-      {showSettingsModal && profile && <SettingsModal profile={profile} onClose={() => setShowSettingsModal(false)} />}
+      {showSettingsModal && profile && <SettingsModal profile={profile} dark={dark} onThemeChange={onThemeChange} onClose={() => setShowSettingsModal(false)} />}
       <CommandPalette open={showCommandPalette} commands={commands} onClose={() => setShowCommandPalette(false)} />
       {showPromptStudio && <PromptStudio onClose={() => setShowPromptStudio(false)} />}
       {showGenerationCenter && <GenerationCenter open onClose={() => setShowGenerationCenter(false)} onManagePlugins={() => setShowPluginsModal(true)} onOpenTest={id => {
@@ -191,7 +191,7 @@ export default function App() {
       },
     }}>
       <AntdApp>
-        <AppShell dark={dark} onToggleTheme={() => setDark(value => !value)} />
+        <AppShell dark={dark} onToggleTheme={() => setDark(value => !value)} onThemeChange={setDark} />
       </AntdApp>
     </ConfigProvider>
   );

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, Button, Divider, Input, InputNumber, Modal, Select, Space, Spin, Switch, Tag, Typography } from 'antd';
+import { Alert, Button, Divider, Input, InputNumber, Modal, Radio, Select, Space, Spin, Switch, Tabs, Tag, Typography } from 'antd';
 import { ReloadOutlined, SearchOutlined, SettingOutlined, UndoOutlined } from '@ant-design/icons';
 import type { StoredAppProfile } from '../db/db';
 import type { GenerationProvider, HardwareProfileId, InterfaceMode } from '../types';
@@ -43,8 +43,31 @@ interface ResolvedSettings {
 
 interface Props {
   profile: StoredAppProfile;
+  dark: boolean;
+  onThemeChange: (dark: boolean) => void;
   onClose: () => void;
 }
+
+type SettingsTab = 'overall' | 'generation' | 'retrieval' | 'documents' | 'advanced';
+
+const settingsTabs: { key: SettingsTab; label: string; description: string }[] = [
+  { key: 'overall', label: 'Overall', description: 'Appearance, interface mode, updates, and hardware profile.' },
+  { key: 'generation', label: 'Generation', description: 'Question generation defaults and provider resource limits.' },
+  { key: 'retrieval', label: 'Retrieval', description: 'Search planning, context, reranking, and embeddings.' },
+  { key: 'documents', label: 'Documents', description: 'Document extraction and OCR behavior.' },
+  { key: 'advanced', label: 'Advanced', description: 'Background work and plugin development settings.' },
+];
+
+const overallExtraSearchTerms = ['theme', 'appearance', 'light', 'dark', 'software update', 'update', 'version', 'stable', 'beta'];
+
+const tabForDefinition = (definition: SettingDefinition): SettingsTab => {
+  const section = definition.key.split('.')[0];
+  if (section === 'interface' || section === 'hardware') return 'overall';
+  if (section === 'generation' || section === 'providers') return 'generation';
+  if (section === 'retrieval' || section === 'embeddings') return 'retrieval';
+  if (section === 'extraction') return 'documents';
+  return 'advanced';
+};
 
 const sectionLabels: Record<string, string> = {
   interface: 'Interface',
@@ -69,13 +92,14 @@ const resourceColor: Record<SettingDefinition['resourceEffect'], string | undefi
   high: '#a61d24',
 };
 
-export default function SettingsModal({ profile, onClose }: Props) {
+export default function SettingsModal({ profile, dark, onThemeChange, onClose }: Props) {
   const [contract, setContract] = useState<SettingsContract>();
   const [resolved, setResolved] = useState<ResolvedSettings>();
   const [draft, setDraft] = useState<SettingsValues>({});
   const [dirtyKeys, setDirtyKeys] = useState<Set<string>>(() => new Set());
   const [unsetKeys, setUnsetKeys] = useState<Set<string>>(() => new Set());
   const [query, setQuery] = useState('');
+  const [activeTab, setActiveTab] = useState<SettingsTab>('overall');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -213,13 +237,22 @@ export default function SettingsModal({ profile, onClose }: Props) {
   };
 
   const advanced = (draft['interface.mode'] ?? profile.interfaceMode) === 'advanced';
+  const visibleDefinitions = useMemo(() => (contract?.registry ?? [])
+    .filter(definition => advanced || definition.visibility === 'basic'), [advanced, contract]);
   const definitions = useMemo(() => {
     const normalized = query.trim().toLowerCase();
-    return (contract?.registry ?? []).filter(definition => (advanced || definition.visibility === 'basic')
-      && (!normalized || [definition.title, definition.description, definition.key, definition.environment]
-        .some(value => value.toLowerCase().includes(normalized))));
-  }, [advanced, contract, query]);
-  const sections = useMemo(() => [...new Set(definitions.map(definition => definition.key.split('.')[0]))], [definitions]);
+    return visibleDefinitions.filter(definition => !normalized || [definition.title, definition.description, definition.key, definition.environment]
+      .some(value => value.toLowerCase().includes(normalized)));
+  }, [query, visibleDefinitions]);
+
+  useEffect(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return;
+    const matchingTab = settingsTabs.find(tab => definitions.some(definition => tabForDefinition(definition) === tab.key)
+      || (tab.key === 'overall' && overallExtraSearchTerms.some(term => term.includes(normalized) || normalized.includes(term))));
+    if (matchingTab) setActiveTab(matchingTab.key);
+  }, [definitions, query]);
+
   const pendingDefinitions = (contract?.registry ?? []).filter(definition => dirtyKeys.has(definition.key) || unsetKeys.has(definition.key));
   const needsReindex = pendingDefinitions.some(definition => definition.reindexRequired);
   const needsRestart = pendingDefinitions.some(definition => definition.restartRequired);
@@ -245,6 +278,93 @@ export default function SettingsModal({ profile, onClose }: Props) {
     return <Input aria-label={definition.title} value={String(value ?? '')} onChange={event => setValue(definition.key, event.target.value)} />;
   };
 
+  const definitionRows = (tab: SettingsTab, suppressEmpty = false) => {
+    const tabDefinitions = definitions.filter(definition => tabForDefinition(definition) === tab);
+    const sections = [...new Set(tabDefinitions.map(definition => definition.key.split('.')[0]))];
+    if (!tabDefinitions.length && suppressEmpty) return null;
+    if (!tabDefinitions.length) return (
+      <Typography.Text type="secondary">
+        {query.trim()
+          ? `No ${settingsTabs.find(item => item.key === tab)?.label.toLowerCase()} settings match this search.`
+          : `No settings are available in this category in ${advanced ? 'Advanced' : 'Simple'} mode.`}
+      </Typography.Text>
+    );
+    return sections.map(section => (
+      <section className="settings-section" key={section} aria-labelledby={`settings-${section}`}>
+        <Divider orientation="left" plain><span id={`settings-${section}`}>{sectionLabels[section] ?? section}</span></Divider>
+        <div className="settings-list">
+          {tabDefinitions.filter(definition => definition.key.startsWith(`${section}.`)).map(definition => {
+            const changed = dirtyKeys.has(definition.key) || unsetKeys.has(definition.key);
+            const selectedProfile = draft['hardware.profile'] as HardwareProfileId;
+            const resetSource = definition.key !== 'hardware.profile' && contract?.profiles[selectedProfile]?.[definition.key] !== undefined
+              ? `profile:${selectedProfile}`
+              : 'default';
+            return <div className={`settings-row${changed ? ' is-changed' : ''}`} key={definition.key}>
+              <div className="settings-copy">
+                <Typography.Text strong>{definition.title}</Typography.Text>
+                <Typography.Text type="secondary">{definition.description}</Typography.Text>
+                <Space size={[4, 4]} wrap>
+                  <Tag>{sourceLabel(unsetKeys.has(definition.key) ? resetSource : resolved?.sources[definition.key] ?? 'default')}</Tag>
+                  {definition.resourceEffect !== 'none' && <Tag color={resourceColor[definition.resourceEffect]}>{definition.resourceEffect} resource impact</Tag>}
+                  {definition.reindexRequired && <Tag color="#8a3b00">Reindex required</Tag>}
+                  {definition.restartRequired && <Tag color="#a8071a">Restart required</Tag>}
+                  {advanced && <Typography.Text code>{definition.key}</Typography.Text>}
+                </Space>
+              </div>
+              <div className="settings-control">
+                {control(definition)}
+                <Button type="text" size="small" icon={<UndoOutlined />} disabled={!changed && resolved?.sources[definition.key] !== 'user'}
+                  aria-label={`Reset ${definition.title}`} onClick={() => resetSetting(definition)}>Reset</Button>
+              </div>
+            </div>;
+          })}
+        </div>
+      </section>
+    ));
+  };
+
+  const overallSearch = query.trim().toLowerCase();
+  const showTheme = !overallSearch || overallExtraSearchTerms.slice(0, 4).some(term => term.includes(overallSearch) || overallSearch.includes(term));
+  const showUpdates = !overallSearch || overallExtraSearchTerms.slice(4).some(term => term.includes(overallSearch) || overallSearch.includes(term));
+  const hasOverallDefinitions = definitions.some(definition => tabForDefinition(definition) === 'overall');
+
+  const overall = <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+    {showTheme && <section className="settings-section" aria-labelledby="settings-appearance">
+      <Divider orientation="left" plain><span id="settings-appearance">Appearance</span></Divider>
+      <div className="settings-list">
+        <div className="settings-row">
+          <div className="settings-copy">
+            <Typography.Text strong>Theme</Typography.Text>
+            <Typography.Text type="secondary">Choose the application color theme. This preference is applied immediately.</Typography.Text>
+            <Space size={[4, 4]} wrap><Tag>App preference</Tag></Space>
+          </div>
+          <div className="settings-control settings-control-single">
+            <div role="radiogroup" aria-label="Theme">
+              <Radio.Group optionType="button" buttonStyle="solid" value={dark ? 'dark' : 'light'}
+                options={[{ label: 'Light', value: 'light' }, { label: 'Dark', value: 'dark' }]}
+                onChange={event => onThemeChange(event.target.value === 'dark')} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>}
+    {definitionRows('overall', showTheme || showUpdates)}
+    {showUpdates && <section className="settings-section" aria-labelledby="settings-updates">
+      <Divider orientation="left" plain><span id="settings-updates">Software updates</span></Divider>
+      <UpdaterStatusView />
+    </section>}
+    {!showTheme && !showUpdates && !hasOverallDefinitions && <Typography.Text type="secondary">No overall settings match this search.</Typography.Text>}
+  </Space>;
+
+  const tabItems = settingsTabs.map(tab => ({
+    key: tab.key,
+    label: tab.label,
+    children: <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>{tab.description}</Typography.Paragraph>
+      {tab.key === 'overall' ? overall : definitionRows(tab.key)}
+    </Space>,
+  }));
+
   return (
     <Modal open title={<Space><SettingOutlined /> Settings</Space>} width={880} onCancel={onClose} footer={[
       <Button key="cancel" onClick={onClose}>Cancel</Button>,
@@ -254,9 +374,8 @@ export default function SettingsModal({ profile, onClose }: Props) {
     ]}>
       <Space direction="vertical" size="middle" style={{ width: '100%' }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-          Search every Quizzer setting, see where its value comes from, and understand resource or indexing impact before saving.
+          Browse settings by category or search across every category. Values show their source and any resource or indexing impact before saving.
         </Typography.Paragraph>
-        <UpdaterStatusView />
         <Input allowClear prefix={<SearchOutlined />} value={query} onChange={event => setQuery(event.target.value)}
           aria-label="Search settings" placeholder="Search settings, descriptions, keys, or environment variables" />
         {error && <Alert type="error" showIcon message={error} action={<Button size="small" icon={<ReloadOutlined />} onClick={() => void load()}>Retry</Button>} />}
@@ -264,38 +383,7 @@ export default function SettingsModal({ profile, onClose }: Props) {
           needsReindex && 'Affected documents must be reindexed.',
           needsRestart && 'Quizzer must be restarted.',
         ].filter(Boolean).join(' ')} />}
-        {loading ? <div className="settings-loading"><Spin /></div> : definitions.length ? sections.map(section => (
-          <section className="settings-section" key={section} aria-labelledby={`settings-${section}`}>
-            <Divider orientation="left" plain><span id={`settings-${section}`}>{sectionLabels[section] ?? section}</span></Divider>
-            <div className="settings-list">
-              {definitions.filter(definition => definition.key.startsWith(`${section}.`)).map(definition => {
-                const changed = dirtyKeys.has(definition.key) || unsetKeys.has(definition.key);
-                const selectedProfile = draft['hardware.profile'] as HardwareProfileId;
-                const resetSource = definition.key !== 'hardware.profile' && contract?.profiles[selectedProfile]?.[definition.key] !== undefined
-                  ? `profile:${selectedProfile}`
-                  : 'default';
-                return <div className={`settings-row${changed ? ' is-changed' : ''}`} key={definition.key}>
-                  <div className="settings-copy">
-                    <Typography.Text strong>{definition.title}</Typography.Text>
-                    <Typography.Text type="secondary">{definition.description}</Typography.Text>
-                    <Space size={[4, 4]} wrap>
-                      <Tag>{sourceLabel(unsetKeys.has(definition.key) ? resetSource : resolved?.sources[definition.key] ?? 'default')}</Tag>
-                      {definition.resourceEffect !== 'none' && <Tag color={resourceColor[definition.resourceEffect]}>{definition.resourceEffect} resource impact</Tag>}
-                      {definition.reindexRequired && <Tag color="#8a3b00">Reindex required</Tag>}
-                      {definition.restartRequired && <Tag color="#a8071a">Restart required</Tag>}
-                      {advanced && <Typography.Text code>{definition.key}</Typography.Text>}
-                    </Space>
-                  </div>
-                  <div className="settings-control">
-                    {control(definition)}
-                    <Button type="text" size="small" icon={<UndoOutlined />} disabled={!changed && resolved?.sources[definition.key] !== 'user'}
-                      aria-label={`Reset ${definition.title}`} onClick={() => resetSetting(definition)}>Reset</Button>
-                  </div>
-                </div>;
-              })}
-            </div>
-          </section>
-        )) : !error && <Typography.Text type="secondary">No settings match this search in {advanced ? 'Advanced' : 'Simple'} mode.</Typography.Text>}
+        {loading ? <div className="settings-loading"><Spin /></div> : !error && <Tabs activeKey={activeTab} onChange={key => setActiveTab(key as SettingsTab)} items={tabItems} />}
       </Space>
     </Modal>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,7 @@ button, input, textarea, select { font: inherit; }
 .settings-row.is-changed { border-color: #1677ff; box-shadow: inset 3px 0 #1677ff; }
 .settings-copy { min-width: 0; display: grid; gap: 5px; }
 .settings-control { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 6px; }
+.settings-control-single { grid-template-columns: 1fr; justify-items: end; }
 .settings-control > .ant-switch { justify-self: end; }
 .settings-control > .ant-input-number, .settings-control > .ant-select { width: 100%; }
 .command-palette-list { max-height: min(58vh, 520px); margin-top: 10px; overflow-y: auto; }

--- a/test/storage.test.mjs
+++ b/test/storage.test.mjs
@@ -516,6 +516,10 @@ test('covers storage validation branches around sync, migration, leases, and com
       pricing: { inputMicroUsdPerMillionTokens: 1, outputMicroUsdPerMillionTokens: 1 } }] }, questions: [], rejected: 0, rounds: {} };
   putRecord('generationJobs', edgeJob.id, edgeJob);
   const edgeLease = 'coverage-edge-lease';
+  assert.throws(() => updateGenerationJobWithLease(edgeJob.id, { workerId: 'coverage-edge-worker', leaseId: edgeLease,
+    patch: { recoveryAttemptId: 'bad' }, now: 200 }), /Invalid generation recovery attempt id/);
+  assert.throws(() => updateGenerationJobWithLease(edgeJob.id, { workerId: 'coverage-edge-worker', leaseId: edgeLease,
+    patch: { recoveryAttemptId: 'coverage-recovery-attempt', status: 'running' }, now: 200 }), /requires a cost_recovery pause/);
   assert.throws(() => finalizeGenerationAttempt(edgeJob.id, { workerId: 'coverage-edge-worker', leaseId: edgeLease,
     attemptId: 'coverage-missing-attempt', usage: { inputTokens: 1, outputTokens: 1 }, now: 201 }), /no reservation/);
   reserveGenerationAttempt(edgeJob.id, { workerId: 'coverage-edge-worker', leaseId: edgeLease,


### PR DESCRIPTION
## Summary
- organize Settings into Overall, Generation, Retrieval, Documents, and Advanced tabs
- move theme, interface mode, hardware profile, and software updates into Overall
- retain global search and select the matching settings tab automatically
- keep source, resource, reindex, and restart context visible

## Verification
- npm run lint
- npm test (393 passed)
- npm run build
- focused Settings browser coverage

Closes #14