### PR TITLE
Simplify the sidebar and configure command shortcuts

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -28,17 +28,18 @@ test('primary application surfaces pass automated WCAG 2.2 AA checks', async ({ 
   const themeTransitionOverride = await page.addStyleTag({
     content: '*, *::before, *::after { transition-duration: 0s !important; }',
   });
-  await page.getByRole('button', { name: 'Dark mode' }).click();
-  const lightMode = page.getByRole('button', { name: 'Light mode' });
-  await expect(lightMode).toBeVisible();
+  await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
+  const themeSettings = page.getByRole('dialog', { name: 'Settings' });
+  await themeSettings.getByText('Dark', { exact: true }).click();
   await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
   await expectNoWcagViolations(page);
-  await page.getByRole('button', { name: 'Light mode' }).click();
+  await themeSettings.getByText('Light', { exact: true }).click();
   await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+  await closeDialog(page, 'Settings', 'Cancel');
   await themeTransitionOverride.evaluate(element => element.remove());
 
   await setInterfaceMode(page, 'advanced');
-  await page.getByRole('button', { name: 'Settings' }).click();
+  await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
   await expect(page.locator('.ant-modal-content').filter({ hasText: 'Settings' })).toBeVisible();
   await expectNoWcagViolations(page);
   await closeDialog(page, 'Settings');

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { dismissOnboarding } from './helpers';
 
-test('exposes semantic main navigation and keyboard-accessible mode control after onboarding', async ({ page }) => {
+test('exposes semantic main navigation and keyboard-accessible settings after onboarding', async ({ page }) => {
   await dismissOnboarding(page);
   const shell = page.locator('.app-shell');
   await expect(shell).toBeVisible({ timeout: 15_000 });
@@ -13,6 +13,7 @@ test('exposes semantic main navigation and keyboard-accessible mode control afte
     navigation.locator('[role="tab"]').filter({ hasText: 'Documents' }),
     navigation.locator('[role="tab"]').filter({ hasText: 'Tests' }),
     navigation.locator('button').filter({ hasText: 'Activity' }),
+    navigation.locator('button').filter({ hasText: 'Settings' }),
   ];
   for (const item of navigationItems) {
     await expect(item).toBeVisible();
@@ -20,7 +21,9 @@ test('exposes semantic main navigation and keyboard-accessible mode control afte
     await expect(item).toBeFocused();
   }
 
-  const mode = page.getByRole('button', { name: /Switch to (Simple|Advanced) mode/ });
+  await navigation.locator('button').filter({ hasText: 'Settings' }).click();
+  const settings = page.getByRole('dialog', { name: 'Settings' });
+  const mode = settings.getByRole('combobox', { name: 'Interface mode' });
   await expect(mode).toBeVisible();
   await mode.focus();
   await expect(mode).toBeFocused();

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -20,12 +20,16 @@ export async function dismissOnboarding(page: Page, navigate = true) {
 }
 
 export async function setInterfaceMode(page: Page, mode: 'simple' | 'advanced') {
-  const switchToTarget = page.getByRole('button', {
-    name: mode === 'advanced' ? 'Switch to Advanced mode' : 'Switch to Simple mode',
-  });
-  const targetIsActive = page.getByRole('button', {
-    name: mode === 'advanced' ? 'Switch to Simple mode' : 'Switch to Advanced mode',
-  });
-  if (await switchToTarget.isVisible()) await switchToTarget.click();
-  await expect(targetIsActive).toBeVisible();
+  await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Settings' });
+  const row = dialog.locator('.settings-row').filter({ hasText: 'Interface mode' });
+  const target = mode === 'advanced' ? 'Advanced' : 'Simple';
+  if (!await row.getByText(target, { exact: true }).isVisible()) {
+    await row.locator('.ant-select-selector').click();
+    await page.locator('.ant-select-dropdown:visible').getByText(target, { exact: true }).click();
+    await dialog.getByRole('button', { name: 'Save changes' }).click();
+  } else {
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+  }
+  await expect(dialog).toBeHidden();
 }

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -148,7 +148,6 @@ test('resumes real onboarding and finishes through durable quiz practice', async
 
   await page.reload();
   await expect(page.getByRole('heading', { name: 'Create your first quiz' })).toBeVisible();
-  await expect(page.getByRole('radio', { name: 'Simple', exact: true })).toBeChecked();
   await expect(page.getByRole('button', { name: 'Continue' })).toBeDisabled();
   await page.locator('.onboarding-drawer').getByRole('button').filter({ hasText: 'Create test' }).click();
   const creationDialog = page.locator('.ant-modal-content').filter({ hasText: 'Create tests from documents' });

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -89,7 +89,7 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await expect(onboarding.locator('.ant-steps-item')).toHaveCount(2);
   await onboarding.getByText('Simple', { exact: true }).click();
   await expect(onboarding.getByRole('radio', { name: /^Simple/ })).toBeChecked();
-  await expect(page.getByRole('button', { name: 'Switch to Advanced mode' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Switch to Advanced mode' })).toHaveCount(0);
   await page.getByRole('button', { name: 'Continue' }).click();
   await expect(page.getByRole('heading', { name: 'Choose a hardware profile' })).toBeVisible();
   await expect(onboarding.locator('.ant-steps-item')).toHaveCount(3);

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -44,3 +44,41 @@ test('Settings search/reset and keyboard accessibility', async ({ page }) => {
   await dialog.getByLabel('Search settings').fill('Generation concurrency');
   await expect(dialog.getByRole('spinbutton', { name: 'Generation concurrency' })).toHaveValue(selectedProfileConcurrency);
 });
+
+test('sidebar stays focused while command shortcuts are configurable and persistent', async ({ page }) => {
+  await dismissOnboarding(page);
+
+  const sidebar = page.locator('.sidebar-footer');
+  await expect(sidebar.getByRole('button', { name: 'Resume setup' })).toBeVisible();
+  await expect(sidebar.getByRole('button', { name: 'Restart tutorial' })).toHaveCount(0);
+  await expect(sidebar.getByRole('button', { name: 'Command palette' })).toHaveCount(0);
+  await expect(sidebar.getByRole('button', { name: /Switch to (Simple|Advanced) mode/ })).toHaveCount(0);
+  await expect(sidebar.getByRole('button', { name: /(Light|Dark) mode/ })).toHaveCount(0);
+
+  await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
+  const settings = page.getByRole('dialog', { name: 'Settings' });
+  await settings.getByRole('tab', { name: 'Shortcuts' }).click();
+
+  const paletteRow = settings.locator('.settings-row').filter({ hasText: 'Open command palette' });
+  await paletteRow.getByRole('button', { name: 'Record shortcut for Open command palette' }).click();
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+Y' : 'Control+Shift+Y');
+  await expect(paletteRow.getByText(process.platform === 'darwin' ? '⌘ ⇧ Y' : 'Ctrl + Shift + Y', { exact: true })).toBeVisible();
+
+  const settingsRow = settings.locator('.settings-row').filter({ hasText: 'Open Settings' });
+  await settingsRow.getByRole('button', { name: 'Record shortcut for Open Settings' }).click();
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+Y' : 'Control+Shift+Y');
+  await expect(page.getByText('That shortcut is already used by Open command palette.')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  await settings.getByRole('button', { name: 'Cancel' }).click();
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+k' : 'Control+k');
+  await expect(page.getByRole('dialog', { name: 'Command palette' })).toHaveCount(0);
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+Y' : 'Control+Shift+Y');
+  await expect(page.getByRole('dialog', { name: 'Command palette' })).toBeVisible();
+  await page.getByRole('dialog', { name: 'Command palette' }).getByRole('button', { name: 'Close' }).click();
+
+  await page.reload();
+  await dismissOnboarding(page, false);
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+Y' : 'Control+Shift+Y');
+  await expect(page.getByRole('dialog', { name: 'Command palette' })).toBeVisible();
+});

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -49,8 +49,9 @@ test('sidebar stays focused while command shortcuts are configurable and persist
   await dismissOnboarding(page);
 
   const sidebar = page.locator('.sidebar-footer');
-  await expect(sidebar.getByRole('button', { name: 'Resume setup' })).toBeVisible();
-  await expect(sidebar.getByRole('button', { name: 'Restart tutorial' })).toHaveCount(0);
+  const tutorialAction = sidebar.locator('button').filter({ hasText: /Resume setup|Restart tutorial/ });
+  await expect(tutorialAction).toHaveCount(1);
+  await expect(tutorialAction).toBeVisible();
   await expect(sidebar.getByRole('button', { name: 'Command palette' })).toHaveCount(0);
   await expect(sidebar.getByRole('button', { name: /Switch to (Simple|Advanced) mode/ })).toHaveCount(0);
   await expect(sidebar.getByRole('button', { name: /(Light|Dark) mode/ })).toHaveCount(0);

--- a/e2e/simple-advanced.spec.ts
+++ b/e2e/simple-advanced.spec.ts
@@ -5,13 +5,9 @@ test('immediate reversible Simple/Advanced disclosure with stored data retained'
   await dismissOnboarding(page);
   await setInterfaceMode(page, 'simple');
 
-  const advancedToggle = page.getByRole('button', { name: 'Switch to Advanced mode' });
-  await expect(advancedToggle).toBeVisible();
-  await advancedToggle.click();
-
-  const simpleToggle = page.getByRole('button', { name: 'Switch to Simple mode' });
   const studioButton = page.getByRole('button', { name: 'Prompt Studio' });
-  await expect(simpleToggle).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Switch to Advanced mode' })).toHaveCount(0);
+  await setInterfaceMode(page, 'advanced');
   await expect(studioButton).toBeVisible();
   await expect(page.getByText('System health', { exact: true })).toBeVisible();
 
@@ -23,17 +19,15 @@ test('immediate reversible Simple/Advanced disclosure with stored data retained'
   await page.locator('.ant-modal-content').filter({ hasText: 'Prompt Studio' })
     .getByRole('button', { name: 'Close', exact: true }).last().click();
 
-  await simpleToggle.click();
-  await expect(advancedToggle).toBeVisible();
+  await setInterfaceMode(page, 'simple');
   await expect(studioButton).toBeHidden();
   await expect(page.getByText('System health', { exact: true })).toHaveCount(0);
 
   await page.reload();
   await dismissOnboarding(page, false);
-  await expect(advancedToggle).toBeVisible();
   await expect(studioButton).toBeHidden();
 
-  await advancedToggle.click();
+  await setInterfaceMode(page, 'advanced');
   await studioButton.click();
   await expect(page.getByRole('button', { name: 'Mode-safe profile' }).first()).toBeVisible();
 });

--- a/e2e/update-notification.spec.ts
+++ b/e2e/update-notification.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test';
+import { dismissOnboarding } from './helpers';
+
+const installUpdaterStub = async (page: import('@playwright/test').Page, outcome: 'available' | 'current' | 'error') => {
+  await page.addInitScript(selectedOutcome => {
+    const calls = { check: 0, status: 0, download: 0, apply: 0 };
+    const status = {
+      state: selectedOutcome === 'available' ? 'available' : 'up-to-date',
+      currentVersion: '1.0.0-beta.5',
+      channel: 'beta',
+      target: { platform: 'darwin', architecture: 'arm64' },
+      keyStatus: { configured: true, trusted: true, id: 'test-key', algorithm: 'Ed25519' },
+      mechanism: 'staged-ready',
+      supported: true,
+      updateInfo: selectedOutcome === 'available' ? {
+        version: '1.0.0-beta.6',
+        channel: 'beta',
+        publishedAt: '2026-09-08T00:00:00.000Z',
+        publicKeyId: 'test-key',
+        artifact: {
+          name: 'Quizzer.pkg', platform: 'darwin', architecture: 'arm64', format: 'pkg',
+          url: 'https://github.com/longnt27/quizzer/releases/download/v1.0.0-beta.6/Quizzer.pkg',
+          size: 1024, sha256: 'a'.repeat(64),
+        },
+      } : undefined,
+    };
+    Object.assign(window, { __startupUpdaterCalls: calls });
+    Object.defineProperty(window, 'quizzerDesktop', {
+      configurable: true,
+      value: { updater: {
+        getStatus: async () => { calls.status += 1; return status; },
+        checkForUpdates: async () => {
+          calls.check += 1;
+          if (selectedOutcome === 'error') throw new Error('offline');
+          return status;
+        },
+        downloadUpdate: async () => { calls.download += 1; return status; },
+        applyUpdate: async () => { calls.apply += 1; throw new Error('not used'); },
+        discardUpdate: async () => ({ discarded: true, status }),
+        rollbackUpdate: async () => { throw new Error('not used'); },
+      } },
+    });
+  }, outcome);
+};
+
+const updaterCalls = (page: import('@playwright/test').Page) => page.evaluate(() => (
+  window as Window & { __startupUpdaterCalls: { check: number; status: number; download: number; apply: number } }
+).__startupUpdaterCalls);
+
+test('notifies once for an available update and opens its Settings details without downloading', async ({ page }) => {
+  await installUpdaterStub(page, 'available');
+  await dismissOnboarding(page);
+
+  const notice = page.locator('.ant-notification-notice').filter({ hasText: 'Quizzer 1.0.0-beta.6 is available' });
+  await expect(notice).toHaveCount(1);
+  await expect(notice.getByRole('status')).toBeVisible();
+  await notice.getByRole('button', { name: 'Review update' }).click();
+
+  const settings = page.getByRole('dialog', { name: 'Settings' });
+  await expect(settings).toBeVisible();
+  await expect(settings.getByRole('tab', { name: 'Overall' })).toHaveAttribute('aria-selected', 'true');
+  await expect(settings.locator('.updater-status-card').getByText('Software Updates', { exact: true })).toBeVisible();
+  await expect.poll(() => updaterCalls(page)).toMatchObject({ check: 1, download: 0, apply: 0 });
+
+  await settings.getByRole('button', { name: 'Cancel' }).click();
+  await page.reload();
+  await dismissOnboarding(page, false);
+  await expect(page.locator('.ant-notification-notice').filter({ hasText: 'is available' })).toHaveCount(0);
+  await expect.poll(() => updaterCalls(page)).toMatchObject({ check: 0, download: 0, apply: 0 });
+});
+
+test('stays silent when the app is current or the startup check fails', async ({ browser }) => {
+  for (const outcome of ['current', 'error'] as const) {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await installUpdaterStub(page, outcome);
+    await page.goto('/');
+    await page.locator('.app-shell').waitFor();
+    await expect.poll(async () => (await updaterCalls(page)).check).toBe(1);
+    await expect(page.locator('.ant-notification-notice').filter({ hasText: 'is available' })).toHaveCount(0);
+    await context.close();
+  }
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { App as AntdApp, Button, ConfigProvider, Drawer, Grid, Layout, theme } from 'antd';
 import { ApiOutlined, ExperimentOutlined, FileAddOutlined, FormOutlined, HomeOutlined, MenuOutlined, MoonOutlined, QuestionCircleOutlined, SettingOutlined, SwapOutlined, SyncOutlined, SunOutlined } from '@ant-design/icons';
 import Sidebar, { type LibrarySelection } from './components/Sidebar';
@@ -22,6 +22,7 @@ import HomePage from './components/HomePage';
 import OnboardingGuide from './components/OnboardingGuide';
 import { recordOnboardingDocument, recordOnboardingGeneration, restartOnboarding, setInterfaceMode } from './utils/appProfile';
 import { useRuntimeSettings } from './utils/useRuntimeSettings';
+import UpdateAvailableNotifier from './components/UpdateAvailableNotifier';
 import {
   SHORTCUT_ACTIONS,
   changeKeyboardShortcut,
@@ -82,6 +83,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     setSession(null);
     setMobileMenuOpen(false);
   };
+  const openSettings = useCallback(() => setShowSettingsModal(true), []);
 
   const updateKeyboardShortcut = (actionId: ShortcutActionId, shortcut: string) => {
     const changed = changeKeyboardShortcut(keyboardShortcuts, actionId, shortcut);
@@ -152,6 +154,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
 
   return <>
     <GenerationWorker />
+    <UpdateAvailableNotifier onOpenSettings={openSettings} />
     <Layout className="app-shell">
       {!mobile && session?.mode !== 'taking' && <Sidebar {...sidebarProps} />}
       {mobile && session?.mode !== 'taking' && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,10 +22,19 @@ import HomePage from './components/HomePage';
 import OnboardingGuide from './components/OnboardingGuide';
 import { recordOnboardingDocument, recordOnboardingGeneration, restartOnboarding, setInterfaceMode } from './utils/appProfile';
 import { useRuntimeSettings } from './utils/useRuntimeSettings';
+import {
+  SHORTCUT_ACTIONS,
+  changeKeyboardShortcut,
+  formatKeyboardShortcut,
+  keyboardShortcutMatches,
+  loadKeyboardShortcuts,
+  saveKeyboardShortcuts,
+  type ShortcutActionId,
+} from './utils/keyboardShortcuts';
 
-interface ShellProps { dark: boolean; onToggleTheme: () => void; onThemeChange: (dark: boolean) => void; }
+interface ShellProps { dark: boolean; onThemeChange: (dark: boolean) => void; }
 
-function AppShell({ dark, onToggleTheme, onThemeChange }: ShellProps) {
+function AppShell({ dark, onThemeChange }: ShellProps) {
   const [selection, setSelection] = useState<LibrarySelection>(null);
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDocumentModal, setShowDocumentModal] = useState(false);
@@ -37,10 +46,12 @@ function AppShell({ dark, onToggleTheme, onThemeChange }: ShellProps) {
   const [showOnboarding, setShowOnboarding] = useState(true);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [session, setSession] = useState<TestSession | null>(null);
+  const [keyboardShortcuts, setKeyboardShortcuts] = useState(loadKeyboardShortcuts);
   const { message: messageApi, modal: modalApi } = AntdApp.useApp();
   const screens = Grid.useBreakpoint();
   const mobile = screens.md === false;
   const profile = useLiveQuery(() => db.profiles.get('default'), []) as StoredAppProfile | undefined;
+  const interfaceMode = profile?.interfaceMode;
   useRuntimeSettings(profile);
   setMessageApi(messageApi);
   setModalApi(modalApi);
@@ -72,6 +83,20 @@ function AppShell({ dark, onToggleTheme, onThemeChange }: ShellProps) {
     setMobileMenuOpen(false);
   };
 
+  const updateKeyboardShortcut = (actionId: ShortcutActionId, shortcut: string) => {
+    const changed = changeKeyboardShortcut(keyboardShortcuts, actionId, shortcut);
+    if (!changed.ok) {
+      messageApi.error(changed.error);
+      return;
+    }
+    try {
+      saveKeyboardShortcuts(changed.shortcuts);
+      setKeyboardShortcuts(changed.shortcuts);
+    } catch {
+      messageApi.error('Could not save keyboard shortcuts');
+    }
+  };
+
   const sidebarProps = {
     selection,
     onSelect: select,
@@ -89,30 +114,40 @@ function AppShell({ dark, onToggleTheme, onThemeChange }: ShellProps) {
 
   useEffect(() => {
     const handleShortcut = (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
-      if (event.key.toLowerCase() === 'k') {
-        event.preventDefault();
-        setShowCommandPalette(true);
-      } else if (event.key === ',') {
-        event.preventDefault();
-        setShowSettingsModal(true);
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (event.defaultPrevented || event.repeat || target?.closest('input, textarea, select, [contenteditable="true"]')) return;
+      const action = SHORTCUT_ACTIONS.find(candidate => keyboardShortcutMatches(event, keyboardShortcuts[candidate.id]));
+      if (!action || (action.id === 'prompts' && interfaceMode !== 'advanced')) return;
+      event.preventDefault();
+      switch (action.id) {
+        case 'command-palette': setShowCommandPalette(true); break;
+        case 'settings': setShowSettingsModal(true); break;
+        case 'home': select(null); break;
+        case 'test-create': setShowAddModal(true); break;
+        case 'document-add': setShowDocumentModal(true); break;
+        case 'activity': setShowGenerationCenter(true); break;
+        case 'plugins': setShowPluginsModal(true); break;
+        case 'prompts': setShowPromptStudio(true); break;
+        case 'mode': if (interfaceMode) void setInterfaceMode(interfaceMode === 'simple' ? 'advanced' : 'simple'); break;
+        case 'tutorial': void restartOnboarding().then(() => setShowOnboarding(true)); break;
+        case 'theme': onThemeChange(!dark); break;
       }
     };
     window.addEventListener('keydown', handleShortcut);
     return () => window.removeEventListener('keydown', handleShortcut);
-  }, []);
+  }, [dark, interfaceMode, keyboardShortcuts, onThemeChange]);
 
   const commands: PaletteCommand[] = [
-    { id: 'home', label: 'Go to Home', description: 'Open recent work, setup progress, and system status.', keywords: ['navigation'], icon: <HomeOutlined />, run: () => select(null) },
-    { id: 'test-create', label: 'Create a test', description: 'Choose sources and generate a new quiz.', keywords: ['quiz', 'generate'], icon: <FormOutlined />, run: () => setShowAddModal(true) },
-    { id: 'document-add', label: 'Add documents', description: 'Import and index source material.', keywords: ['import', 'pdf', 'text'], icon: <FileAddOutlined />, run: () => setShowDocumentModal(true) },
-    { id: 'activity', label: 'Open Activity', description: 'Review indexing and generation checkpoints.', keywords: ['activity', 'jobs', 'indexing'], icon: <SyncOutlined />, run: () => setShowGenerationCenter(true) },
-    { id: 'plugins', label: 'Open plugins & models', description: 'Configure providers, extraction, OCR, and external plugins.', keywords: ['provider', 'api', 'models'], icon: <ApiOutlined />, run: () => setShowPluginsModal(true) },
-    { id: 'settings', label: 'Open Settings', description: 'Search and edit resolved application settings.', shortcut: '⌘ ,', icon: <SettingOutlined />, run: () => setShowSettingsModal(true) },
-    ...(profile?.interfaceMode === 'advanced' ? [{ id: 'prompts', label: 'Open Prompt Studio', description: 'Edit, validate, preview, import, and export prompt profiles.', keywords: ['templates', 'generation', 'grading', 'rag'], icon: <ExperimentOutlined />, run: () => setShowPromptStudio(true) }] : []),
-    { id: 'mode', label: `Switch to ${profile?.interfaceMode === 'advanced' ? 'Simple' : 'Advanced'} mode`, description: 'Change disclosure without changing stored capabilities or data.', keywords: ['interface'], icon: <SwapOutlined />, run: () => profile && setInterfaceMode(profile.interfaceMode === 'simple' ? 'advanced' : 'simple') },
-    { id: 'tutorial', label: 'Restart tutorial', description: 'Return to the resumable first-run walkthrough.', keywords: ['help', 'onboarding'], icon: <QuestionCircleOutlined />, run: async () => { await restartOnboarding(); setShowOnboarding(true); } },
-    { id: 'theme', label: `Use ${dark ? 'light' : 'dark'} theme`, description: 'Change the application color theme.', keywords: ['appearance'], icon: dark ? <SunOutlined /> : <MoonOutlined />, run: onToggleTheme },
+    { id: 'home', label: 'Go to Home', description: 'Open recent work, setup progress, and system status.', keywords: ['navigation'], shortcut: formatKeyboardShortcut(keyboardShortcuts.home), icon: <HomeOutlined />, run: () => select(null) },
+    { id: 'test-create', label: 'Create a test', description: 'Choose sources and generate a new quiz.', keywords: ['quiz', 'generate'], shortcut: formatKeyboardShortcut(keyboardShortcuts['test-create']), icon: <FormOutlined />, run: () => setShowAddModal(true) },
+    { id: 'document-add', label: 'Add documents', description: 'Import and index source material.', keywords: ['import', 'pdf', 'text'], shortcut: formatKeyboardShortcut(keyboardShortcuts['document-add']), icon: <FileAddOutlined />, run: () => setShowDocumentModal(true) },
+    { id: 'activity', label: 'Open Activity', description: 'Review indexing and generation checkpoints.', keywords: ['activity', 'jobs', 'indexing'], shortcut: formatKeyboardShortcut(keyboardShortcuts.activity), icon: <SyncOutlined />, run: () => setShowGenerationCenter(true) },
+    { id: 'plugins', label: 'Open plugins & models', description: 'Configure providers, extraction, OCR, and external plugins.', keywords: ['provider', 'api', 'models'], shortcut: formatKeyboardShortcut(keyboardShortcuts.plugins), icon: <ApiOutlined />, run: () => setShowPluginsModal(true) },
+    { id: 'settings', label: 'Open Settings', description: 'Search and edit resolved application settings.', shortcut: formatKeyboardShortcut(keyboardShortcuts.settings), icon: <SettingOutlined />, run: () => setShowSettingsModal(true) },
+    ...(profile?.interfaceMode === 'advanced' ? [{ id: 'prompts', label: 'Open Prompt Studio', description: 'Edit, validate, preview, import, and export prompt profiles.', keywords: ['templates', 'generation', 'grading', 'rag'], shortcut: formatKeyboardShortcut(keyboardShortcuts.prompts), icon: <ExperimentOutlined />, run: () => setShowPromptStudio(true) }] : []),
+    { id: 'mode', label: `Switch to ${profile?.interfaceMode === 'advanced' ? 'Simple' : 'Advanced'} mode`, description: 'Change disclosure without changing stored capabilities or data.', keywords: ['interface'], shortcut: formatKeyboardShortcut(keyboardShortcuts.mode), icon: <SwapOutlined />, run: () => profile && setInterfaceMode(profile.interfaceMode === 'simple' ? 'advanced' : 'simple') },
+    { id: 'tutorial', label: 'Restart tutorial', description: 'Return to the resumable first-run walkthrough.', keywords: ['help', 'onboarding'], shortcut: formatKeyboardShortcut(keyboardShortcuts.tutorial), icon: <QuestionCircleOutlined />, run: async () => { await restartOnboarding(); setShowOnboarding(true); } },
+    { id: 'theme', label: `Use ${dark ? 'light' : 'dark'} theme`, description: 'Change the application color theme.', keywords: ['appearance'], shortcut: formatKeyboardShortcut(keyboardShortcuts.theme), icon: dark ? <SunOutlined /> : <MoonOutlined />, run: () => onThemeChange(!dark) },
   ];
 
   return <>
@@ -150,7 +185,9 @@ function AppShell({ dark, onToggleTheme, onThemeChange }: ShellProps) {
         setSelection({ kind: 'document', id }); setShowDocumentModal(false);
       }} />}
       {showPluginsModal && profile && <PluginsModal interfaceMode={profile.interfaceMode} onClose={() => setShowPluginsModal(false)} />}
-      {showSettingsModal && profile && <SettingsModal profile={profile} dark={dark} onThemeChange={onThemeChange} onClose={() => setShowSettingsModal(false)} />}
+      {showSettingsModal && profile && <SettingsModal profile={profile} dark={dark} onThemeChange={onThemeChange}
+        keyboardShortcuts={keyboardShortcuts} onKeyboardShortcutChange={updateKeyboardShortcut}
+        onOpenCommandPalette={() => { setShowSettingsModal(false); setShowCommandPalette(true); }} onClose={() => setShowSettingsModal(false)} />}
       <CommandPalette open={showCommandPalette} commands={commands} onClose={() => setShowCommandPalette(false)} />
       {showPromptStudio && <PromptStudio onClose={() => setShowPromptStudio(false)} />}
       {showGenerationCenter && <GenerationCenter open onClose={() => setShowGenerationCenter(false)} onManagePlugins={() => setShowPluginsModal(true)} onOpenTest={id => {
@@ -188,7 +225,7 @@ export default function App() {
       },
     }}>
       <AntdApp>
-        <AppShell dark={dark} onToggleTheme={() => setDark(value => !value)} onThemeChange={setDark} />
+        <AppShell dark={dark} onThemeChange={setDark} />
       </AntdApp>
     </ConfigProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,11 +78,11 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     return () => { active = false; };
   }, []);
 
-  const select = (next: LibrarySelection) => {
+  const select = useCallback((next: LibrarySelection) => {
     setSelection(next);
     setSession(null);
     setMobileMenuOpen(false);
-  };
+  }, []);
   const openSettings = useCallback(() => setShowSettingsModal(true), []);
 
   const updateKeyboardShortcut = (actionId: ShortcutActionId, shortcut: string) => {
@@ -137,7 +137,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     };
     window.addEventListener('keydown', handleShortcut);
     return () => window.removeEventListener('keydown', handleShortcut);
-  }, [dark, interfaceMode, keyboardShortcuts, onThemeChange]);
+  }, [dark, interfaceMode, keyboardShortcuts, onThemeChange, select]);
 
   const commands: PaletteCommand[] = [
     { id: 'home', label: 'Go to Home', description: 'Open recent work, setup progress, and system status.', keywords: ['navigation'], shortcut: formatKeyboardShortcut(keyboardShortcuts.home), icon: <HomeOutlined />, run: () => select(null) },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,15 +79,12 @@ function AppShell({ dark, onToggleTheme, onThemeChange }: ShellProps) {
     onAddDocument: () => { setShowDocumentModal(true); setMobileMenuOpen(false); },
     onOpenPlugins: () => { setShowPluginsModal(true); setMobileMenuOpen(false); },
     onOpenSettings: () => { setShowSettingsModal(true); setMobileMenuOpen(false); },
-    onOpenCommandPalette: () => { setShowCommandPalette(true); setMobileMenuOpen(false); },
     onOpenPromptStudio: () => { setShowPromptStudio(true); setMobileMenuOpen(false); },
     onOpenGeneration: () => { setShowGenerationCenter(true); setMobileMenuOpen(false); },
     onOpenHome: () => select(null),
     onOpenTutorial: () => { setShowOnboarding(true); setMobileMenuOpen(false); },
     profile,
-    onToggleInterfaceMode: () => profile && void setInterfaceMode(profile.interfaceMode === 'simple' ? 'advanced' : 'simple'),
     dark,
-    onToggleTheme,
   };
 
   useEffect(() => {

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Alert, Badge, Button, Card, Col, Empty, List, Progress, Radio, Row, Space, Statistic, Tag, Typography } from 'antd';
+import { Alert, Badge, Button, Card, Col, Empty, List, Progress, Row, Space, Statistic, Tag, Typography } from 'antd';
 import { ApiOutlined, DatabaseOutlined, FileAddOutlined, FormOutlined, PlayCircleOutlined, ReloadOutlined, RocketOutlined, SafetyCertificateOutlined, SyncOutlined } from '@ant-design/icons';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db, type StoredAppProfile } from '../db/db';
-import type { InterfaceMode } from '../types';
-import { CURRENT_WHATS_NEW_VERSION, ONBOARDING_STEPS, setInterfaceMode, updateAppProfile } from '../utils/appProfile';
+import { CURRENT_WHATS_NEW_VERSION, ONBOARDING_STEPS, updateAppProfile } from '../utils/appProfile';
 import { serviceRequest } from '../utils/serviceApi';
 import { useConfiguredProviders } from '../utils/useConfiguredProviders';
 
@@ -83,8 +82,6 @@ export default function HomePage({ profile, onAddDocument, onAddTest, onOpenGene
         <Typography.Title level={2}>Welcome to Quizzer</Typography.Title>
         <Typography.Paragraph type="secondary">Turn your own documents into focused, source-grounded practice.</Typography.Paragraph>
       </div>
-      <Radio.Group data-onboarding-target="mode" aria-label="Interface mode" optionType="button" buttonStyle="solid" value={profile.interfaceMode} onChange={event => void setInterfaceMode(event.target.value as InterfaceMode)}
-        options={[{ label: 'Simple', value: 'simple' }, { label: 'Advanced', value: 'advanced' }]} />
     </div>
 
     {showWhatsNew && <Alert closable type="info" showIcon icon={<RocketOutlined />} message="Quizzer 1.0 setup is here"

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { Alert, Button, Divider, Input, InputNumber, Modal, Radio, Select, Space, Spin, Switch, Tabs, Tag, Typography } from 'antd';
 import { ReloadOutlined, SearchOutlined, SettingOutlined, UndoOutlined } from '@ant-design/icons';
 import type { StoredAppProfile } from '../db/db';
@@ -9,6 +9,15 @@ import { getProviderSettings, PROVIDERS, setProviderSettings } from '../utils/pr
 import { getMessageApi } from '../utils/messageProvider';
 import { getModalApi } from '../utils/modalProvider';
 import { serviceJson, serviceRequest } from '../utils/serviceApi';
+import {
+  DEFAULT_KEYBOARD_SHORTCUTS,
+  SHORTCUT_ACTIONS,
+  changeKeyboardShortcut,
+  formatKeyboardShortcut,
+  shortcutFromKeyboardEvent,
+  type KeyboardShortcuts,
+  type ShortcutActionId,
+} from '../utils/keyboardShortcuts';
 import UpdaterStatusView from './UpdaterStatus';
 
 type SettingValue = string | number | boolean;
@@ -45,13 +54,17 @@ interface Props {
   profile: StoredAppProfile;
   dark: boolean;
   onThemeChange: (dark: boolean) => void;
+  keyboardShortcuts: KeyboardShortcuts;
+  onKeyboardShortcutChange: (actionId: ShortcutActionId, shortcut: string) => void;
+  onOpenCommandPalette: () => void;
   onClose: () => void;
 }
 
-type SettingsTab = 'overall' | 'generation' | 'retrieval' | 'documents' | 'advanced';
+type SettingsTab = 'overall' | 'shortcuts' | 'generation' | 'retrieval' | 'documents' | 'advanced';
 
 const settingsTabs: { key: SettingsTab; label: string; description: string }[] = [
   { key: 'overall', label: 'Overall', description: 'Appearance, interface mode, updates, and hardware profile.' },
+  { key: 'shortcuts', label: 'Shortcuts', description: 'Open the command palette or assign safe keyboard shortcuts to its actions.' },
   { key: 'generation', label: 'Generation', description: 'Question generation defaults and provider resource limits.' },
   { key: 'retrieval', label: 'Retrieval', description: 'Search planning, context, reranking, and embeddings.' },
   { key: 'documents', label: 'Documents', description: 'Document extraction and OCR behavior.' },
@@ -59,6 +72,10 @@ const settingsTabs: { key: SettingsTab; label: string; description: string }[] =
 ];
 
 const overallExtraSearchTerms = ['theme', 'appearance', 'light', 'dark', 'software update', 'update', 'version', 'stable', 'beta'];
+const shortcutExtraSearchTerms = [
+  'keyboard', 'shortcut', 'command palette',
+  ...SHORTCUT_ACTIONS.flatMap(action => [action.label.toLowerCase(), action.description.toLowerCase()]),
+];
 
 const tabForDefinition = (definition: SettingDefinition): SettingsTab => {
   const section = definition.key.split('.')[0];
@@ -92,7 +109,15 @@ const resourceColor: Record<SettingDefinition['resourceEffect'], string | undefi
   high: '#a61d24',
 };
 
-export default function SettingsModal({ profile, dark, onThemeChange, onClose }: Props) {
+export default function SettingsModal({
+  profile,
+  dark,
+  onThemeChange,
+  keyboardShortcuts,
+  onKeyboardShortcutChange,
+  onOpenCommandPalette,
+  onClose,
+}: Props) {
   const [contract, setContract] = useState<SettingsContract>();
   const [resolved, setResolved] = useState<ResolvedSettings>();
   const [draft, setDraft] = useState<SettingsValues>({});
@@ -100,6 +125,7 @@ export default function SettingsModal({ profile, dark, onThemeChange, onClose }:
   const [unsetKeys, setUnsetKeys] = useState<Set<string>>(() => new Set());
   const [query, setQuery] = useState('');
   const [activeTab, setActiveTab] = useState<SettingsTab>('overall');
+  const [recordingShortcut, setRecordingShortcut] = useState<ShortcutActionId>();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -249,7 +275,8 @@ export default function SettingsModal({ profile, dark, onThemeChange, onClose }:
     const normalized = query.trim().toLowerCase();
     if (!normalized) return;
     const matchingTab = settingsTabs.find(tab => definitions.some(definition => tabForDefinition(definition) === tab.key)
-      || (tab.key === 'overall' && overallExtraSearchTerms.some(term => term.includes(normalized) || normalized.includes(term))));
+      || (tab.key === 'overall' && overallExtraSearchTerms.some(term => term.includes(normalized) || normalized.includes(term)))
+      || (tab.key === 'shortcuts' && shortcutExtraSearchTerms.some(term => term.includes(normalized) || normalized.includes(term))));
     if (matchingTab) setActiveTab(matchingTab.key);
   }, [definitions, query]);
 
@@ -356,12 +383,79 @@ export default function SettingsModal({ profile, dark, onThemeChange, onClose }:
     {!showTheme && !showUpdates && !hasOverallDefinitions && <Typography.Text type="secondary">No overall settings match this search.</Typography.Text>}
   </Space>;
 
+  const applyShortcut = (actionId: ShortcutActionId, shortcut: string) => {
+    const changed = changeKeyboardShortcut(keyboardShortcuts, actionId, shortcut);
+    if (!changed.ok) {
+      message.error(changed.error);
+      return;
+    }
+    onKeyboardShortcutChange(actionId, changed.shortcuts[actionId]);
+    setRecordingShortcut(undefined);
+  };
+
+  const captureShortcut = (event: ReactKeyboardEvent<HTMLElement>, actionId: ShortcutActionId) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.key === 'Escape') {
+      setRecordingShortcut(undefined);
+      return;
+    }
+    if (event.key === 'Backspace' || event.key === 'Delete') {
+      applyShortcut(actionId, '');
+      return;
+    }
+    const shortcut = shortcutFromKeyboardEvent(event.nativeEvent);
+    if (!shortcut) {
+      message.warning('Press Ctrl or Command with one supported key. Add Shift or Alt if needed.');
+      return;
+    }
+    applyShortcut(actionId, shortcut);
+  };
+
+  const shortcutActions = SHORTCUT_ACTIONS.filter(action => !overallSearch
+    || [action.label, action.description].some(value => value.toLowerCase().includes(overallSearch))
+    || ['keyboard', 'shortcut'].some(value => value.includes(overallSearch) || overallSearch.includes(value)));
+
+  const shortcutSettings = <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+    <Alert type="info" showIcon message="Keyboard shortcuts use Ctrl on Windows/Linux and Command on macOS."
+      description="Changes are saved immediately. Choose Record, then press a primary modifier and one key. Press Backspace to clear or Escape to cancel. Duplicate and operating-system-reserved shortcuts are rejected." />
+    <Button onClick={onOpenCommandPalette}>Open command palette</Button>
+    {shortcutActions.length ? <section className="settings-section" aria-labelledby="settings-keyboard-shortcuts">
+      <Divider orientation="left" plain><span id="settings-keyboard-shortcuts">Command palette actions</span></Divider>
+      <div className="settings-list">
+        {shortcutActions.map(action => {
+          const shortcut = keyboardShortcuts[action.id];
+          const recording = recordingShortcut === action.id;
+          return <div className="settings-row" key={action.id}>
+            <div className="settings-copy">
+              <Typography.Text strong>{action.label}</Typography.Text>
+              <Typography.Text type="secondary">{action.description}</Typography.Text>
+              <Space size={[4, 4]} wrap>
+                <Tag color={shortcut ? 'blue' : undefined}>{shortcut ? formatKeyboardShortcut(shortcut) : 'Not assigned'}</Tag>
+              </Space>
+            </div>
+            <Space className="settings-shortcut-actions" wrap>
+              <Button type={recording ? 'primary' : 'default'} aria-label={`Record shortcut for ${action.label}`}
+                onClick={() => setRecordingShortcut(action.id)} onBlur={() => setRecordingShortcut(current => current === action.id ? undefined : current)}
+                onKeyDown={recording ? event => captureShortcut(event, action.id) : undefined}>
+                {recording ? 'Press shortcut…' : 'Record'}
+              </Button>
+              <Button aria-label={`Clear shortcut for ${action.label}`} disabled={!shortcut} onClick={() => applyShortcut(action.id, '')}>Clear</Button>
+              <Button aria-label={`Reset shortcut for ${action.label}`} disabled={shortcut === DEFAULT_KEYBOARD_SHORTCUTS[action.id]}
+                onClick={() => applyShortcut(action.id, DEFAULT_KEYBOARD_SHORTCUTS[action.id])}>Reset</Button>
+            </Space>
+          </div>;
+        })}
+      </div>
+    </section> : <Typography.Text type="secondary">No shortcut actions match this search.</Typography.Text>}
+  </Space>;
+
   const tabItems = settingsTabs.map(tab => ({
     key: tab.key,
     label: tab.label,
     children: <Space direction="vertical" size="middle" style={{ width: '100%' }}>
       <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>{tab.description}</Typography.Paragraph>
-      {tab.key === 'overall' ? overall : definitionRows(tab.key)}
+      {tab.key === 'overall' ? overall : tab.key === 'shortcuts' ? shortcutSettings : definitionRows(tab.key)}
     </Space>,
   }));
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useSyncExternalStore } from 'react';
 import { Alert, Badge, Button, Empty, Input, Layout, List, Modal, Popconfirm, Progress, Space, Tabs, Tag, Typography } from 'antd';
-import { ApiOutlined, CloudSyncOutlined, DeleteOutlined, ExperimentOutlined, FileTextOutlined, FormOutlined, HomeOutlined, MacCommandOutlined, MoonOutlined, PlusOutlined, QuestionCircleOutlined, SearchOutlined, SettingOutlined, SwapOutlined, SyncOutlined, SunOutlined } from '@ant-design/icons';
+import { ApiOutlined, CloudSyncOutlined, DeleteOutlined, ExperimentOutlined, FileTextOutlined, FormOutlined, HomeOutlined, PlusOutlined, QuestionCircleOutlined, SearchOutlined, SettingOutlined, SyncOutlined } from '@ant-design/icons';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db, type StoredAppProfile } from '../db/db';
 import { getMessageApi } from '../utils/messageProvider';
@@ -29,19 +29,16 @@ interface Props {
   onAddDocument: () => void;
   onOpenPlugins: () => void;
   onOpenSettings: () => void;
-  onOpenCommandPalette: () => void;
   onOpenPromptStudio: () => void;
   onOpenGeneration: () => void;
   onOpenHome: () => void;
   onOpenTutorial: () => void;
   profile?: StoredAppProfile;
-  onToggleInterfaceMode: () => void;
   dark: boolean;
-  onToggleTheme: () => void;
   embedded?: boolean;
 }
 
-export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument, onOpenPlugins, onOpenSettings, onOpenCommandPalette, onOpenPromptStudio, onOpenGeneration, onOpenHome, onOpenTutorial, profile, onToggleInterfaceMode, dark, onToggleTheme, embedded = false }: Props) {
+export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument, onOpenPlugins, onOpenSettings, onOpenPromptStudio, onOpenGeneration, onOpenHome, onOpenTutorial, profile, dark, embedded = false }: Props) {
   const tests = useLiveQuery(() => db.tests.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const documents = useLiveQuery(() => db.documents.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const [tab, setTab] = useState<'tests' | 'documents'>(selection?.kind === 'document' ? 'documents' : 'tests');
@@ -114,7 +111,13 @@ export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument,
         )}
       </div>
       <div className="sidebar-footer">
-        {profile && !profile.onboarding.completedAt && !profile.onboarding.skipped && <Button type="primary" icon={<QuestionCircleOutlined />} onClick={onOpenTutorial}>Resume setup</Button>}
+        {profile && <Button type={!profile.onboarding.completedAt && !profile.onboarding.skipped ? 'primary' : 'text'} icon={<QuestionCircleOutlined />}
+          onClick={async () => {
+            if (profile.onboarding.completedAt || profile.onboarding.skipped) await restartOnboarding();
+            onOpenTutorial();
+          }}>
+          {!profile.onboarding.completedAt && !profile.onboarding.skipped ? 'Resume setup' : 'Restart tutorial'}
+        </Button>}
         <Button type="text" icon={<CloudSyncOutlined spin={sync.status === 'syncing'} />} onClick={() => { setSyncDetailsOpen(true); void syncNow(); }}>
           <Badge status={sync.status === 'synced' ? 'success' : sync.status === 'offline' ? 'warning' : 'processing'} />
           {sync.status === 'offline' ? 'Offline — saved locally' : sync.lastSyncedAt ? 'Saved on server' : 'Syncing library'}
@@ -123,14 +126,6 @@ export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument,
         <Button data-onboarding-target="provider" type="text" icon={<ApiOutlined />} onClick={onOpenPlugins}>Plugins & models</Button>
         <Button type="text" icon={<SettingOutlined />} onClick={onOpenSettings}>Settings</Button>
         {profile?.interfaceMode === 'advanced' && <Button type="text" icon={<ExperimentOutlined />} onClick={onOpenPromptStudio}>Prompt Studio</Button>}
-        <Button type="text" icon={<MacCommandOutlined />} onClick={onOpenCommandPalette}>Command palette <span className="sidebar-shortcut">⌘/Ctrl K</span></Button>
-        {profile && <Button type="text" icon={<SwapOutlined />} onClick={onToggleInterfaceMode}>
-          Switch to {profile.interfaceMode === 'simple' ? 'Advanced' : 'Simple'} mode
-        </Button>}
-        <Button type="text" icon={<QuestionCircleOutlined />} onClick={async () => { await restartOnboarding(); onOpenTutorial(); }}>Restart tutorial</Button>
-        <Button type="text" icon={dark ? <SunOutlined /> : <MoonOutlined />} onClick={onToggleTheme}>
-          {dark ? 'Light mode' : 'Dark mode'}
-        </Button>
       </div>
       <Modal title="Library sync" open={syncDetailsOpen} onCancel={() => setSyncDetailsOpen(false)} footer={[
         <Button key="sync" loading={sync.status === 'syncing'} onClick={() => void syncNow()}>Sync now</Button>,

--- a/src/components/UpdateAvailableNotifier.tsx
+++ b/src/components/UpdateAvailableNotifier.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { App as AntdApp, Button } from 'antd';
+import type { QuizzerDesktopUpdaterApi, UpdaterStatus } from '../types/updater';
+
+const UPDATE_CHECK_SESSION_KEY = 'quizzer.startupUpdateCheck.v1';
+const UPDATE_NOTIFICATION_KEY = 'quizzer-update-available';
+
+let startupUpdateCheck: Promise<UpdaterStatus | null> | undefined;
+
+const checkOncePerSession = (updater: QuizzerDesktopUpdaterApi) => {
+  if (startupUpdateCheck) return startupUpdateCheck;
+  try {
+    if (sessionStorage.getItem(UPDATE_CHECK_SESSION_KEY)) return Promise.resolve(null);
+    sessionStorage.setItem(UPDATE_CHECK_SESSION_KEY, 'started');
+  } catch { /* The in-memory promise still prevents duplicate checks in restricted storage contexts. */ }
+  startupUpdateCheck = updater.checkForUpdates().catch(() => null);
+  return startupUpdateCheck;
+};
+
+interface Props {
+  onOpenSettings: () => void;
+}
+
+export default function UpdateAvailableNotifier({ onOpenSettings }: Props) {
+  const { notification } = AntdApp.useApp();
+
+  useEffect(() => {
+    const updater = window.quizzerDesktop?.updater;
+    if (!updater) return;
+    let active = true;
+    void checkOncePerSession(updater).then(status => {
+      if (!active || status?.state !== 'available' || !status.updateInfo) return;
+      notification.info({
+        key: UPDATE_NOTIFICATION_KEY,
+        role: 'status',
+        duration: 0,
+        placement: 'bottomLeft',
+        message: `Quizzer ${status.updateInfo.version} is available`,
+        description: 'Review the signed update in Settings when you are ready. Quizzer will not download or install it automatically.',
+        actions: <Button type="primary" size="small" onClick={() => {
+          notification.destroy(UPDATE_NOTIFICATION_KEY);
+          onOpenSettings();
+        }}>Review update</Button>,
+      });
+    });
+    return () => { active = false; };
+  }, [notification, onOpenSettings]);
+
+  return null;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,6 @@ button, input, textarea, select { font: inherit; }
 .sidebar-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 0 8px; }
 .sidebar-footer { margin: 8px 12px 14px; flex: 0 0 auto; display: grid; gap: 2px; }
 .sidebar-footer .ant-btn { justify-content: flex-start; }
-.sidebar-shortcut { margin-left: auto; font-size: 11px; color: var(--text-muted); }
 .plugin-loading { display: grid; min-height: 220px; place-items: center; }
 .plugin-modal-intro { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
 .plugin-option-list { display: grid; gap: 10px; }

--- a/src/index.css
+++ b/src/index.css
@@ -72,6 +72,7 @@ button, input, textarea, select { font: inherit; }
 .settings-control-single { grid-template-columns: 1fr; justify-items: end; }
 .settings-control > .ant-switch { justify-self: end; }
 .settings-control > .ant-input-number, .settings-control > .ant-select { width: 100%; }
+.settings-shortcut-actions { justify-content: flex-end; }
 .command-palette-list { max-height: min(58vh, 520px); margin-top: 10px; overflow-y: auto; }
 .command-palette-list .ant-list-item { padding: 0; border-block-end: 0; }
 .command-palette-command { width: 100%; min-height: 62px; padding: 10px 12px; display: grid; grid-template-columns: 30px minmax(0, 1fr) auto; gap: 10px; align-items: center; border: 0; border-radius: 8px; color: var(--text); background: transparent; text-align: left; cursor: pointer; }
@@ -283,6 +284,7 @@ mark { color: #111827; }
   .home-page { padding: 20px 14px 36px; }
   .home-heading, .home-card-heading { align-items: stretch; flex-direction: column; gap: 10px; }
   .settings-row { grid-template-columns: 1fr; gap: 12px; }
+  .settings-shortcut-actions { justify-content: flex-start; }
   .prompt-studio-layout { min-height: auto; grid-template-columns: 1fr; }
   .prompt-profile-sidebar { max-height: 260px; border-right: 0; border-bottom: 1px solid var(--border); padding: 0 0 14px; }
   .prompt-studio-heading { align-items: stretch; flex-direction: column; }

--- a/src/utils/keyboardShortcuts.ts
+++ b/src/utils/keyboardShortcuts.ts
@@ -1,0 +1,185 @@
+export const KEYBOARD_SHORTCUT_STORAGE_KEY = 'quizzer.keyboardShortcuts.v1';
+
+export const SHORTCUT_ACTIONS = [
+  { id: 'command-palette', label: 'Open command palette', description: 'Search and run every Quizzer command.' },
+  { id: 'settings', label: 'Open Settings', description: 'Open application settings.' },
+  { id: 'home', label: 'Go to Home', description: 'Return to the application home screen.' },
+  { id: 'test-create', label: 'Create a test', description: 'Open test creation.' },
+  { id: 'document-add', label: 'Add documents', description: 'Open document import.' },
+  { id: 'activity', label: 'Open Activity', description: 'Review active and completed work.' },
+  { id: 'plugins', label: 'Open plugins & models', description: 'Configure providers, tools, and plugins.' },
+  { id: 'prompts', label: 'Open Prompt Studio', description: 'Open prompt profiles when Advanced mode is active.' },
+  { id: 'mode', label: 'Switch interface mode', description: 'Toggle between Simple and Advanced mode.' },
+  { id: 'tutorial', label: 'Restart tutorial', description: 'Restart the guided setup.' },
+  { id: 'theme', label: 'Switch theme', description: 'Toggle between the light and dark themes.' },
+] as const;
+
+export type ShortcutActionId = typeof SHORTCUT_ACTIONS[number]['id'];
+export type KeyboardShortcuts = Record<ShortcutActionId, string>;
+
+export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcuts = {
+  'command-palette': 'Mod+K',
+  settings: 'Mod+Comma',
+  home: '',
+  'test-create': '',
+  'document-add': '',
+  activity: '',
+  plugins: '',
+  prompts: '',
+  mode: '',
+  tutorial: '',
+  theme: '',
+};
+
+interface KeyboardEventLike {
+  key: string;
+  code?: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+const namedKeys = new Set([
+  'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End', 'PageUp', 'PageDown',
+  'Enter', 'Space', 'Comma', 'Period', 'Slash', 'Semicolon', 'Quote', 'BracketLeft',
+  'BracketRight', 'Backslash', 'Minus', 'Equal', 'Backquote',
+]);
+
+const reservedPrimaryShortcuts = new Set(['Mod+A', 'Mod+C', 'Mod+F', 'Mod+L', 'Mod+N', 'Mod+P', 'Mod+Q', 'Mod+R', 'Mod+S', 'Mod+T', 'Mod+V', 'Mod+W', 'Mod+X', 'Mod+Z']);
+
+const keyAliases: Record<string, string> = {
+  ' ': 'Space',
+  spacebar: 'Space',
+  ',': 'Comma',
+  '.': 'Period',
+  '/': 'Slash',
+  ';': 'Semicolon',
+  "'": 'Quote',
+  '[': 'BracketLeft',
+  ']': 'BracketRight',
+  '\\': 'Backslash',
+  '-': 'Minus',
+  '=': 'Equal',
+  '`': 'Backquote',
+};
+
+const canonicalKey = (input: string) => {
+  const trimmed = input.trim();
+  const alias = keyAliases[trimmed.toLowerCase()] ?? keyAliases[trimmed];
+  if (alias) return alias;
+  if (/^[a-z0-9]$/i.test(trimmed)) return trimmed.toUpperCase();
+  if (/^f(?:[1-9]|1[0-2])$/i.test(trimmed)) return trimmed.toUpperCase();
+  const named = [...namedKeys].find(key => key.toLowerCase() === trimmed.toLowerCase());
+  return named ?? null;
+};
+
+const eventKey = (event: KeyboardEventLike) => {
+  const code = event.code ?? '';
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3);
+  if (/^Digit[0-9]$/.test(code)) return code.slice(5);
+  if (namedKeys.has(code)) return code;
+  return canonicalKey(event.key);
+};
+
+export const normalizeKeyboardShortcut = (input: string): string | null => {
+  if (!input.trim()) return '';
+  const parts = input.split('+').map(part => part.trim()).filter(Boolean);
+  let mod = false;
+  let shift = false;
+  let alt = false;
+  let key: string | null = null;
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (lower === 'mod' || lower === 'meta' || lower === 'cmd' || lower === 'command' || lower === 'ctrl' || lower === 'control') {
+      if (mod) return null;
+      mod = true;
+    } else if (lower === 'shift') {
+      if (shift) return null;
+      shift = true;
+    } else if (lower === 'alt' || lower === 'option') {
+      if (alt) return null;
+      alt = true;
+    } else {
+      if (key) return null;
+      key = canonicalKey(part);
+      if (!key) return null;
+    }
+  }
+  if (!mod || !key) return null;
+  const normalized = ['Mod', shift && 'Shift', alt && 'Alt', key].filter(Boolean).join('+');
+  return reservedPrimaryShortcuts.has(normalized) ? null : normalized;
+};
+
+export const shortcutFromKeyboardEvent = (event: KeyboardEventLike): string | null => {
+  if ((!event.metaKey && !event.ctrlKey) || (event.metaKey && event.ctrlKey)) return null;
+  const key = eventKey(event);
+  if (!key) return null;
+  return ['Mod', event.shiftKey && 'Shift', event.altKey && 'Alt', key].filter(Boolean).join('+');
+};
+
+export const keyboardShortcutMatches = (event: KeyboardEventLike, shortcut: string) => {
+  const normalized = normalizeKeyboardShortcut(shortcut);
+  if (!normalized || (event.metaKey && event.ctrlKey) || (!event.metaKey && !event.ctrlKey)) return false;
+  const parts = new Set(normalized.split('+'));
+  return parts.has('Shift') === event.shiftKey
+    && parts.has('Alt') === event.altKey
+    && parts.has(eventKey(event) ?? '');
+};
+
+const displayKeys: Record<string, string> = {
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  Semicolon: ';',
+  Quote: "'",
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backslash: '\\',
+  Minus: '-',
+  Equal: '=',
+  Backquote: '`',
+};
+
+export const formatKeyboardShortcut = (shortcut: string, apple = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)) => {
+  const normalized = normalizeKeyboardShortcut(shortcut);
+  if (!normalized) return '';
+  const parts = normalized.split('+');
+  const key = displayKeys[parts.at(-1) ?? ''] ?? parts.at(-1);
+  if (apple) return [parts.includes('Mod') && '⌘', parts.includes('Shift') && '⇧', parts.includes('Alt') && '⌥', key].filter(Boolean).join(' ');
+  return [parts.includes('Mod') && 'Ctrl', parts.includes('Shift') && 'Shift', parts.includes('Alt') && 'Alt', key].filter(Boolean).join(' + ');
+};
+
+export const normalizeKeyboardShortcuts = (value: unknown): KeyboardShortcuts => {
+  const stored = value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+  const used = new Set<string>();
+  return Object.fromEntries(SHORTCUT_ACTIONS.map(action => {
+    const raw = Object.hasOwn(stored, action.id) ? stored[action.id] : DEFAULT_KEYBOARD_SHORTCUTS[action.id];
+    const normalized = typeof raw === 'string' ? normalizeKeyboardShortcut(raw) : null;
+    const fallback = normalizeKeyboardShortcut(DEFAULT_KEYBOARD_SHORTCUTS[action.id]) ?? '';
+    const shortcut = normalized === null ? fallback : normalized;
+    if (!shortcut || used.has(shortcut)) return [action.id, ''];
+    used.add(shortcut);
+    return [action.id, shortcut];
+  })) as KeyboardShortcuts;
+};
+
+export const changeKeyboardShortcut = (current: KeyboardShortcuts, actionId: ShortcutActionId, shortcut: string) => {
+  const normalized = normalizeKeyboardShortcut(shortcut);
+  if (normalized === null) return { ok: false as const, error: 'Use Ctrl/Command with a supported key that is not reserved by the operating system or browser.' };
+  const conflict = normalized && SHORTCUT_ACTIONS.find(action => action.id !== actionId && current[action.id] === normalized);
+  if (conflict) return { ok: false as const, error: `That shortcut is already used by ${conflict.label}.` };
+  return { ok: true as const, shortcuts: { ...current, [actionId]: normalized } };
+};
+
+export const loadKeyboardShortcuts = (): KeyboardShortcuts => {
+  try {
+    return normalizeKeyboardShortcuts(JSON.parse(localStorage.getItem(KEYBOARD_SHORTCUT_STORAGE_KEY) ?? '{}'));
+  } catch {
+    return normalizeKeyboardShortcuts({});
+  }
+};
+
+export const saveKeyboardShortcuts = (shortcuts: KeyboardShortcuts) => {
+  localStorage.setItem(KEYBOARD_SHORTCUT_STORAGE_KEY, JSON.stringify(normalizeKeyboardShortcuts(shortcuts)));
+};

--- a/test/keyboard-shortcuts.test.mjs
+++ b/test/keyboard-shortcuts.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_KEYBOARD_SHORTCUTS,
+  changeKeyboardShortcut,
+  formatKeyboardShortcut,
+  keyboardShortcutMatches,
+  normalizeKeyboardShortcut,
+  normalizeKeyboardShortcuts,
+  shortcutFromKeyboardEvent,
+} from '../src/utils/keyboardShortcuts.ts';
+
+const keyEvent = (overrides = {}) => ({
+  key: 'k', code: 'KeyK', metaKey: true, ctrlKey: false, shiftKey: false, altKey: false, ...overrides,
+});
+
+test('normalizes only safe primary-modifier keyboard chords', () => {
+  assert.equal(normalizeKeyboardShortcut('command + shift + k'), 'Mod+Shift+K');
+  assert.equal(normalizeKeyboardShortcut('Ctrl+,'), 'Mod+Comma');
+  assert.equal(normalizeKeyboardShortcut('K'), null);
+  assert.equal(normalizeKeyboardShortcut('Mod'), null);
+  assert.equal(normalizeKeyboardShortcut('Mod+Shift+K+P'), null);
+  assert.equal(normalizeKeyboardShortcut('Mod+Escape'), null);
+  assert.equal(normalizeKeyboardShortcut('Mod+Q'), null);
+  assert.equal(normalizeKeyboardShortcut('Mod+Shift+Q'), 'Mod+Shift+Q');
+});
+
+test('captures and matches exact cross-platform shortcut modifiers', () => {
+  assert.equal(shortcutFromKeyboardEvent(keyEvent({ shiftKey: true })), 'Mod+Shift+K');
+  assert.equal(shortcutFromKeyboardEvent(keyEvent({ metaKey: false, ctrlKey: true, code: 'Comma', key: ',' })), 'Mod+Comma');
+  assert.equal(shortcutFromKeyboardEvent(keyEvent({ metaKey: true, ctrlKey: true })), null);
+  assert.equal(keyboardShortcutMatches(keyEvent(), 'Mod+K'), true);
+  assert.equal(keyboardShortcutMatches(keyEvent({ shiftKey: true }), 'Mod+K'), false);
+  assert.equal(keyboardShortcutMatches(keyEvent({ altKey: true }), 'Mod+Alt+K'), true);
+});
+
+test('sanitizes persisted settings and rejects shortcut conflicts', () => {
+  const sanitized = normalizeKeyboardShortcuts({
+    'command-palette': 'garbage',
+    settings: 'Mod+K',
+    home: 'Mod+Shift+H',
+    theme: 42,
+  });
+  assert.equal(sanitized['command-palette'], DEFAULT_KEYBOARD_SHORTCUTS['command-palette']);
+  assert.equal(sanitized.settings, '');
+  assert.equal(sanitized.home, 'Mod+Shift+H');
+  assert.equal(sanitized.theme, '');
+
+  const conflict = changeKeyboardShortcut(sanitized, 'settings', 'Mod+Shift+H');
+  assert.equal(conflict.ok, false);
+  assert.match(conflict.error, /Go to Home/);
+  const changed = changeKeyboardShortcut(sanitized, 'settings', 'Mod+Period');
+  assert.equal(changed.ok, true);
+  assert.equal(changed.shortcuts.settings, 'Mod+Period');
+  const reserved = changeKeyboardShortcut(sanitized, 'settings', 'Mod+W');
+  assert.equal(reserved.ok, false);
+  assert.match(reserved.error, /reserved/);
+});
+
+test('formats shortcuts for native platform conventions', () => {
+  assert.equal(formatKeyboardShortcut('Mod+Shift+Comma', true), '⌘ ⇧ ,');
+  assert.equal(formatKeyboardShortcut('Mod+Alt+K', false), 'Ctrl + Alt + K');
+  assert.equal(formatKeyboardShortcut('', false), '');
+});


### PR DESCRIPTION
## Summary
- remove theme, interface-mode, and command-palette controls from the sidebar and consolidate setup/tour into one contextual action
- add a Settings shortcuts tab for safe, persistent, conflict-checked command shortcuts
- honor configured shortcuts globally while protecting text-entry controls
- notify once per app session when a compatible signed update is available, with a user-controlled action to review it in Settings

## Verification
- npm run lint
- npm test (397 passed)
- npm run build
- full browser suite: 15 existing scenarios passed before the final locator correction
- corrected sidebar/settings scenario passed independently
- update notification scenarios passed (available/current/error, no automatic download or apply)
- focused Chromium + Firefox navigation/onboarding checks passed

Stacked on #24 so this review shows only issue #16. After #24 merges, this PR can target develop directly.

Closes #16