### PR TITLE
fix: test taking background covers entire scrollable height

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -238,7 +238,7 @@ button, input, textarea, select { font: inherit; }
 .test-start-button { width: 150px; height: 48px; padding-inline: 36px; border-radius: 24px; font-size: 16px; }
 
 .quiz-layout { width: 100%; height: 100dvh; background: var(--page); flex-wrap: nowrap; }
-.quiz-main { min-width: 0; background: var(--surface); }
+.quiz-main { min-width: 0; background: var(--surface); overflow-y: auto; }
 .quiz-header { padding: 32px 24px 18px; background: var(--surface-soft); border-bottom: 1px solid var(--border); }
 .quiz-body { padding: 34px 30px; }
 .quiz-actions { width: 100%; margin-bottom: 32px; gap: 12px; }


### PR DESCRIPTION
Closes #38. Fixed the bug where overflowing content in TestTaking dropped onto a black/unintended background by applying `overflow-y: auto` to `.quiz-main`, which natively restrains content within the container without disrupting layout or independent component scroll settings.