### PR TITLE
Make desktop updates automatic and one-click on macOS

### DIFF
--- a/desktop/macos-update.mjs
+++ b/desktop/macos-update.mjs
@@ -1,0 +1,191 @@
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { constants } from 'node:fs';
+import { access, lstat, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, normalize, resolve } from 'node:path';
+
+export const QUIZZER_BUNDLE_IDENTIFIER = 'dev.quizzer.app';
+export const INSTALLED_APPLICATION_PATH = '/Applications/Quizzer.app';
+
+const HELPER_SOURCE = `#!/bin/sh
+set -u
+
+current_pid="$1"
+target_app="$2"
+next_app="$3"
+previous_app="$4"
+staging_dir="$5"
+preparation_dir="$6"
+log_file="$7"
+
+exec >>"$log_file" 2>&1
+
+attempt=0
+while /bin/kill -0 "$current_pid" 2>/dev/null && [ "$attempt" -lt 120 ]; do
+  /bin/sleep 0.25
+  attempt=$((attempt + 1))
+done
+
+if /bin/kill -0 "$current_pid" 2>/dev/null; then
+  echo "Quizzer did not exit before the update timeout"
+  exit 1
+fi
+
+if [ ! -d "$target_app" ] || [ ! -d "$next_app" ] || [ -e "$previous_app" ]; then
+  echo "Update paths were not in the expected state"
+  exit 1
+fi
+
+if ! /bin/mv "$target_app" "$previous_app"; then
+  echo "Could not retain the installed Quizzer application"
+  exit 1
+fi
+
+if ! /bin/mv "$next_app" "$target_app"; then
+  echo "Could not install the prepared Quizzer application; restoring the previous version"
+  /bin/mv "$previous_app" "$target_app"
+  exit 1
+fi
+
+# Remove the consumed package before relaunch so the new process cannot recover
+# it as another pending update. These paths are created and validated by Quizzer.
+/bin/rm -rf "$staging_dir"
+
+if /usr/bin/open -n "$target_app"; then
+  /bin/rm -rf "$previous_app"
+  /bin/rm -rf "$preparation_dir"
+  exit 0
+fi
+
+echo "Could not relaunch updated Quizzer; restoring the previous version"
+/bin/rm -rf "$target_app"
+/bin/mv "$previous_app" "$target_app"
+/usr/bin/open -n "$target_app"
+exit 1
+`;
+
+const runFile = (command, args) => new Promise((resolveCommand, reject) => {
+  execFile(command, args, { encoding: 'utf8', maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
+    if (error) {
+      reject(new Error(`${command} failed: ${(stderr || error.message).trim()}`));
+      return;
+    }
+    resolveCommand({ stdout, stderr });
+  });
+});
+
+const assertDirectoryWithoutSymlink = async (path, label) => {
+  const info = await lstat(path);
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error(`${label} must be a directory and cannot be a symbolic link`);
+  }
+};
+
+const assertRegularFileWithoutSymlink = async (path, label) => {
+  const info = await lstat(path);
+  if (!info.isFile() || info.isSymbolicLink()) {
+    throw new Error(`${label} must be a regular file and cannot be a symbolic link`);
+  }
+};
+
+export const validateInstalledApplicationPath = (applicationPath, requiredPath = INSTALLED_APPLICATION_PATH) => {
+  const resolvedRequiredPath = normalize(resolve(requiredPath));
+  if (typeof applicationPath !== 'string' || normalize(resolve(applicationPath)) !== resolvedRequiredPath) {
+    throw new Error(`Automatic macOS updates require Quizzer to run from ${resolvedRequiredPath}`);
+  }
+  return resolvedRequiredPath;
+};
+
+export const macosUpdateHelperSource = () => HELPER_SOURCE;
+
+export const prepareMacosDmgUpdate = async ({
+  dmgPath,
+  userDataDir,
+  applicationPath,
+  currentPid,
+  targetVersion,
+  bundleIdentifier = QUIZZER_BUNDLE_IDENTIFIER,
+  runner = runFile,
+  requiredApplicationPath = INSTALLED_APPLICATION_PATH,
+} = {}) => {
+  if (typeof dmgPath !== 'string' || !dmgPath) throw new Error('A verified DMG path is required');
+  if (typeof userDataDir !== 'string' || !userDataDir) throw new Error('User data directory is required');
+  if (!Number.isSafeInteger(currentPid) || currentPid <= 0) throw new Error('A valid Quizzer process ID is required');
+  if (typeof targetVersion !== 'string' || !targetVersion) throw new Error('The signed target version is required');
+
+  const targetApp = validateInstalledApplicationPath(applicationPath, requiredApplicationPath);
+  await assertDirectoryWithoutSymlink(targetApp, 'Installed Quizzer application');
+  await access(dirname(targetApp), constants.W_OK);
+
+  const updatesDirectory = join(userDataDir, 'updates');
+  const stagingDirectory = dirname(resolve(dmgPath));
+  if (stagingDirectory !== resolve(join(updatesDirectory, 'staging'))) {
+    throw new Error('Verified DMG must be inside Quizzer private update staging');
+  }
+  await assertRegularFileWithoutSymlink(dmgPath, 'Verified DMG');
+  await mkdir(updatesDirectory, { recursive: true, mode: 0o700 });
+  const preparationDirectory = join(updatesDirectory, `prepared-${randomUUID()}`);
+  const mountDirectory = join(preparationDirectory, 'mount');
+  const nextApp = join(preparationDirectory, 'Quizzer.next');
+  const previousApp = join(preparationDirectory, 'Quizzer.previous');
+  const helperPath = join(preparationDirectory, 'install-update.sh');
+  const logFile = join(updatesDirectory, 'install-update.log');
+  let attached = false;
+
+  await mkdir(mountDirectory, { recursive: true, mode: 0o700 });
+  try {
+    await runner('/usr/bin/hdiutil', ['attach', '-nobrowse', '-readonly', '-mountpoint', mountDirectory, dmgPath]);
+    attached = true;
+
+    const entries = await readdir(mountDirectory, { withFileTypes: true });
+    const applicationEntries = entries.filter(entry => entry.isDirectory() && entry.name.toLowerCase().endsWith('.app'));
+    if (applicationEntries.length !== 1) {
+      throw new Error(`Verified DMG must contain exactly one application bundle; found ${applicationEntries.length}`);
+    }
+
+    const sourceApp = join(mountDirectory, applicationEntries[0].name);
+    await assertDirectoryWithoutSymlink(sourceApp, 'DMG application bundle');
+    const infoPlist = join(sourceApp, 'Contents', 'Info.plist');
+    const identifierResult = await runner('/usr/libexec/PlistBuddy', ['-c', 'Print :CFBundleIdentifier', infoPlist]);
+    if (identifierResult.stdout.trim() !== bundleIdentifier) {
+      throw new Error(`DMG application bundle identifier does not match ${bundleIdentifier}`);
+    }
+    const versionResult = await runner('/usr/libexec/PlistBuddy', ['-c', 'Print :CFBundleShortVersionString', infoPlist]);
+    if (versionResult.stdout.trim() !== targetVersion) {
+      throw new Error(`DMG application version ${versionResult.stdout.trim() || '(missing)'} does not match signed version ${targetVersion}`);
+    }
+
+    await runner('/usr/bin/ditto', ['--noqtn', sourceApp, nextApp]);
+    await assertDirectoryWithoutSymlink(nextApp, 'Prepared Quizzer application');
+    await writeFile(helperPath, HELPER_SOURCE, { mode: 0o700 });
+  } catch (error) {
+    if (attached) await runner('/usr/bin/hdiutil', ['detach', mountDirectory, '-force']).catch(() => {});
+    await rm(preparationDirectory, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+
+  try {
+    await runner('/usr/bin/hdiutil', ['detach', mountDirectory]);
+    attached = false;
+    await rm(mountDirectory, { recursive: true, force: true });
+  } catch (error) {
+    if (attached) await runner('/usr/bin/hdiutil', ['detach', mountDirectory, '-force']).catch(() => {});
+    await rm(preparationDirectory, { recursive: true, force: true }).catch(() => {});
+    throw new Error(`Could not detach the verified update image: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return {
+    command: '/bin/sh',
+    args: [
+      helperPath,
+      String(currentPid),
+      targetApp,
+      nextApp,
+      previousApp,
+      stagingDirectory,
+      preparationDirectory,
+      logFile,
+    ],
+    preparationDirectory,
+  };
+};

--- a/desktop/macos-update.mjs
+++ b/desktop/macos-update.mjs
@@ -155,7 +155,7 @@ export const prepareMacosDmgUpdate = async ({
       throw new Error(`DMG application version ${versionResult.stdout.trim() || '(missing)'} does not match signed version ${targetVersion}`);
     }
 
-    await runner('/usr/bin/ditto', ['--noqtn', sourceApp, nextApp]);
+    await runner('/usr/bin/ditto', [sourceApp, nextApp]);
     await assertDirectoryWithoutSymlink(nextApp, 'Prepared Quizzer application');
     await writeFile(helperPath, HELPER_SOURCE, { mode: 0o700 });
   } catch (error) {

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -8,7 +8,7 @@ import { isAllowedExternalUrl, isTrustedRendererUrl } from './security.mjs';
 import { executableSearchPath, serviceRestartDelay, waitForServiceReady } from './service-process.mjs';
 import { protectedBackgroundFallback, summarizeBackgroundState } from './background-policy.mjs';
 import { DesktopUpdater } from './updater.mjs';
-import { validateUpdaterCheckOptions, validateUpdaterApplyOptions } from './updater-ipc.mjs';
+import { validateAutoDownloadPreference, validateUpdaterCheckOptions, validateUpdaterApplyOptions } from './updater-ipc.mjs';
 import { RELEASE_TRUSTED_KEYS } from '../release/trust.mjs';
 
 protocol.registerSchemesAsPrivileged([{ scheme: 'quizzer', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }]);
@@ -95,6 +95,10 @@ const registerValidatedIpc = () => {
   ipcMain.handle('updater:download', async event => {
     if (!isTrustedRenderer(event)) throw new Error('Untrusted renderer');
     return desktopUpdater?.downloadUpdate();
+  });
+  ipcMain.handle('updater:set-auto-download', async (event, enabled) => {
+    if (!isTrustedRenderer(event)) throw new Error('Untrusted renderer');
+    return desktopUpdater?.setAutoDownload(validateAutoDownloadPreference(enabled));
   });
   ipcMain.handle('updater:apply', async (event, options) => {
     if (!isTrustedRenderer(event)) throw new Error('Untrusted renderer');
@@ -316,6 +320,8 @@ app.whenReady().then(async () => {
     userDataDir: app.getPath('userData'),
     currentVersion: app.getVersion() || '1.0.0-beta.5',
     isPackaged: app.isPackaged,
+    applicationPath: dirname(dirname(dirname(app.getPath('exe')))),
+    currentPid: process.pid,
     fetch: net.fetch,
     trustedKeys: RELEASE_TRUSTED_KEYS,
   });

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -17,6 +17,7 @@ contextBridge.exposeInMainWorld('quizzerDesktop', Object.freeze({
     getStatus: () => ipcRenderer.invoke('updater:status'),
     checkForUpdates: options => ipcRenderer.invoke('updater:check', options),
     downloadUpdate: () => ipcRenderer.invoke('updater:download'),
+    setAutoDownload: enabled => ipcRenderer.invoke('updater:set-auto-download', enabled),
     applyUpdate: options => ipcRenderer.invoke('updater:apply', options),
     discardUpdate: () => ipcRenderer.invoke('updater:discard'),
     rollbackUpdate: () => ipcRenderer.invoke('updater:rollback'),

--- a/desktop/updater-ipc.mjs
+++ b/desktop/updater-ipc.mjs
@@ -57,3 +57,10 @@ export const validateUpdaterApplyOptions = options => {
   }
   return validated;
 };
+
+export const validateAutoDownloadPreference = enabled => {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('autoDownload must be a boolean');
+  }
+  return enabled;
+};

--- a/desktop/updater.mjs
+++ b/desktop/updater.mjs
@@ -5,6 +5,7 @@ import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { verifyReleaseManifestSignature } from '../release/manifest.mjs';
 import { isValidArtifactName, MAX_DESKTOP_PACKAGE_SIZE, validateReleaseManifest } from '../server/release-manifest.mjs';
+import { prepareMacosDmgUpdate } from './macos-update.mjs';
 
 export const SUPPORTED_CHANNELS = Object.freeze(['stable', 'beta']);
 export const CANONICAL_REPOSITORY = 'longnt27/quizzer';
@@ -167,7 +168,7 @@ export const fetchBoundedText = async (fetchFn, url, options = {}, maxBytes = MA
 };
 
 const FORMAT_PREFERENCES = {
-  macos: ['pkg', 'dmg', 'zip'],
+  macos: ['dmg', 'pkg', 'zip'],
   windows: ['msi', 'exe', 'zip'],
   linux: ['deb', 'rpm', 'appimage', 'tar.gz', 'zip'],
 };
@@ -438,8 +439,17 @@ export const resolveHandoffLaunch = (filePath, format, platform) => {
   return { command: '/usr/bin/xdg-open', args: [filePath] };
 };
 
-export const defaultLauncher = async (filePath, format, platform) => {
-  const { command, args } = resolveHandoffLaunch(filePath, format, platform);
+export const defaultLauncher = async (filePath, format, platform, context = {}) => {
+  const launch = platform === 'macos' && format === 'dmg'
+    ? await prepareMacosDmgUpdate({
+        dmgPath: filePath,
+        userDataDir: context.userDataDir,
+        applicationPath: context.applicationPath,
+        currentPid: context.currentPid,
+        targetVersion: context.targetVersion,
+      })
+    : resolveHandoffLaunch(filePath, format, platform);
+  const { command, args } = launch;
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: 'ignore',
@@ -452,6 +462,9 @@ export const defaultLauncher = async (filePath, format, platform) => {
     child.on('error', (err) => {
       if (!settled) {
         settled = true;
+        if (launch.preparationDirectory) {
+          void rm(launch.preparationDirectory, { recursive: true, force: true }).catch(() => {});
+        }
         reject(new Error(`Failed to launch installer: ${err.message}`));
       }
     });
@@ -476,8 +489,11 @@ export class DesktopUpdater {
     this.isPackaged = options.isPackaged ?? false;
     this.fetch = options.fetch || globalThis.fetch;
     this.launcher = options.launcher || defaultLauncher;
+    this.applicationPath = options.applicationPath || '';
+    this.currentPid = options.currentPid || process.pid;
 
     this.channel = this.loadPersistedChannelSync(options.channel);
+    this.autoDownload = this.loadPersistedAutoDownloadSync(options.autoDownload);
 
     this.trustedKeys = new Map();
     if (options.trustedKeys) {
@@ -543,6 +559,37 @@ export class DesktopUpdater {
     const payload = JSON.stringify({ channel, updatedAt: new Date().toISOString() }, null, 2);
     await writeFile(tempFile, `${payload}\n`, { mode: 0o600 });
     await rename(tempFile, channelFile);
+  }
+
+  loadPersistedAutoDownloadSync(fallbackAutoDownload) {
+    if (this.userDataDir) {
+      try {
+        const preferencesFile = join(this.userDataDir, 'updates', 'preferences.json');
+        const parsed = JSON.parse(readFileSync(preferencesFile, 'utf8'));
+        if (typeof parsed?.autoDownload === 'boolean') return parsed.autoDownload;
+      } catch {
+        // Fall back to the configured preference or the safe product default.
+      }
+    }
+    return typeof fallbackAutoDownload === 'boolean' ? fallbackAutoDownload : true;
+  }
+
+  async persistAutoDownload(autoDownload) {
+    if (!this.userDataDir) return;
+    const updatesDir = join(this.userDataDir, 'updates');
+    await mkdir(updatesDir, { recursive: true, mode: 0o700 });
+    const preferencesFile = join(updatesDir, 'preferences.json');
+    const tempFile = `${preferencesFile}.${process.pid}.${Date.now()}.tmp`;
+    const payload = JSON.stringify({ autoDownload, updatedAt: new Date().toISOString() }, null, 2);
+    await writeFile(tempFile, `${payload}\n`, { mode: 0o600 });
+    await rename(tempFile, preferencesFile);
+  }
+
+  async setAutoDownload(autoDownload) {
+    if (typeof autoDownload !== 'boolean') throw new Error('autoDownload must be a boolean');
+    this.autoDownload = autoDownload;
+    await this.persistAutoDownload(autoDownload);
+    return this.getStatus();
   }
 
   resolvePublicKey(publicKeyId) {
@@ -885,6 +932,7 @@ export class DesktopUpdater {
       state: this.state,
       currentVersion: this.currentVersion,
       channel: this.channel,
+      autoDownload: this.autoDownload,
       target: {
         platform: this.platform,
         architecture: this.architecture,
@@ -1256,7 +1304,12 @@ export class DesktopUpdater {
       }
 
       try {
-        await this.launcher(artifactPath, format, this.platform);
+        await this.launcher(artifactPath, format, this.platform, {
+          userDataDir: this.userDataDir,
+          applicationPath: this.applicationPath,
+          currentPid: this.currentPid,
+          targetVersion: stagedPackage.manifest.version,
+        });
       } catch (err) {
         this.state = 'error';
         this.lastError = `Installer handoff failed: ${err instanceof Error ? err.message : String(err)}`;
@@ -1271,7 +1324,9 @@ export class DesktopUpdater {
         handoffPending: true,
         restartRequested: options.restart ?? false,
         mechanism: 'staged-ready',
-        message: 'Update package cryptographically verified and successfully handed off to system installer.',
+        message: this.platform === 'macos' && format === 'dmg'
+          ? 'Update verified and prepared. Quizzer will install it and restart now.'
+          : 'Update package cryptographically verified and successfully handed off to system installer.',
         status: await this.getStatus(),
       };
     } catch (error) {
@@ -1397,7 +1452,12 @@ export class DesktopUpdater {
     }
 
     try {
-      await this.launcher(candidate.artifactPath, candidate.artifact.format, this.platform);
+      await this.launcher(candidate.artifactPath, candidate.artifact.format, this.platform, {
+        userDataDir: this.userDataDir,
+        applicationPath: this.applicationPath,
+        currentPid: this.currentPid,
+        targetVersion: candidate.manifest.version,
+      });
     } catch (error) {
       this.state = 'error';
       this.lastError = `Rollback installer handoff failed: ${error instanceof Error ? error.message : String(error)}`;

--- a/e2e/update-notification.spec.ts
+++ b/e2e/update-notification.spec.ts
@@ -1,28 +1,36 @@
 import { expect, test } from '@playwright/test';
 import { dismissOnboarding } from './helpers';
 
-const installUpdaterStub = async (page: import('@playwright/test').Page, outcome: 'available' | 'current' | 'error') => {
-  await page.addInitScript(selectedOutcome => {
-    const calls = { check: 0, status: 0, download: 0, apply: 0 };
-    const status = {
-      state: selectedOutcome === 'available' ? 'available' : 'up-to-date',
+type Outcome = 'available' | 'current' | 'error';
+
+const installUpdaterStub = async (
+  page: import('@playwright/test').Page,
+  outcome: Outcome,
+  autoDownload = true,
+) => {
+  await page.addInitScript(({ selectedOutcome, automatic }) => {
+    const calls = { check: 0, status: 0, download: 0, apply: 0, setAutoDownload: 0, restart: false };
+    const updateInfo = selectedOutcome === 'available' ? {
+      version: '1.0.0-beta.6',
+      channel: 'beta',
+      publishedAt: '2026-09-08T00:00:00.000Z',
+      publicKeyId: 'test-key',
+      artifact: {
+        name: 'Quizzer.dmg', platform: 'macos', architecture: 'arm64', format: 'dmg',
+        url: 'https://github.com/longnt27/quizzer/releases/download/v1.0.0-beta.6/Quizzer.dmg',
+        size: 1024, sha256: 'a'.repeat(64),
+      },
+    } : undefined;
+    let status = {
+      state: 'idle',
       currentVersion: '1.0.0-beta.5',
       channel: 'beta',
-      target: { platform: 'darwin', architecture: 'arm64' },
+      autoDownload: automatic,
+      target: { platform: 'macos', architecture: 'arm64' },
       keyStatus: { configured: true, trusted: true, id: 'test-key', algorithm: 'Ed25519' },
       mechanism: 'staged-ready',
       supported: true,
-      updateInfo: selectedOutcome === 'available' ? {
-        version: '1.0.0-beta.6',
-        channel: 'beta',
-        publishedAt: '2026-09-08T00:00:00.000Z',
-        publicKeyId: 'test-key',
-        artifact: {
-          name: 'Quizzer.pkg', platform: 'darwin', architecture: 'arm64', format: 'pkg',
-          url: 'https://github.com/longnt27/quizzer/releases/download/v1.0.0-beta.6/Quizzer.pkg',
-          size: 1024, sha256: 'a'.repeat(64),
-        },
-      } : undefined,
+      updateInfo: undefined,
     };
     Object.assign(window, { __startupUpdaterCalls: calls });
     Object.defineProperty(window, 'quizzerDesktop', {
@@ -32,41 +40,79 @@ const installUpdaterStub = async (page: import('@playwright/test').Page, outcome
         checkForUpdates: async () => {
           calls.check += 1;
           if (selectedOutcome === 'error') throw new Error('offline');
+          status = { ...status, state: selectedOutcome === 'available' ? 'available' : 'up-to-date', updateInfo };
           return status;
         },
-        downloadUpdate: async () => { calls.download += 1; return status; },
-        applyUpdate: async () => { calls.apply += 1; throw new Error('not used'); },
+        downloadUpdate: async () => {
+          calls.download += 1;
+          status = { ...status, state: 'downloaded' };
+          return status;
+        },
+        setAutoDownload: async (enabled: boolean) => {
+          calls.setAutoDownload += 1;
+          status = { ...status, autoDownload: enabled };
+          return status;
+        },
+        applyUpdate: async (options?: { restart?: boolean }) => {
+          calls.apply += 1;
+          calls.restart = options?.restart === true;
+          return {
+            applied: false,
+            handoffPending: true,
+            restartRequested: calls.restart,
+            mechanism: 'staged-ready',
+            message: 'Installing',
+            status,
+          };
+        },
         discardUpdate: async () => ({ discarded: true, status }),
         rollbackUpdate: async () => { throw new Error('not used'); },
       } },
     });
-  }, outcome);
+  }, { selectedOutcome: outcome, automatic: autoDownload });
 };
 
 const updaterCalls = (page: import('@playwright/test').Page) => page.evaluate(() => (
-  window as Window & { __startupUpdaterCalls: { check: number; status: number; download: number; apply: number } }
+  window as Window & { __startupUpdaterCalls: {
+    check: number;
+    status: number;
+    download: number;
+    apply: number;
+    setAutoDownload: number;
+    restart: boolean;
+  } }
 ).__startupUpdaterCalls);
 
-test('notifies once for an available update and opens its Settings details without downloading', async ({ page }) => {
+test('downloads an available update automatically and installs it with one restart click', async ({ page }) => {
   await installUpdaterStub(page, 'available');
   await dismissOnboarding(page);
 
-  const notice = page.locator('.ant-notification-notice').filter({ hasText: 'Quizzer 1.0.0-beta.6 is available' });
+  const notice = page.locator('.ant-notification-notice').filter({ hasText: 'Quizzer 1.0.0-beta.6 is ready to install' });
   await expect(notice).toHaveCount(1);
   await expect(notice.getByRole('status')).toBeVisible();
-  await notice.getByRole('button', { name: 'Review update' }).click();
+  await expect.poll(() => updaterCalls(page)).toMatchObject({ check: 1, status: 1, download: 1, apply: 0 });
 
-  const settings = page.getByRole('dialog', { name: 'Settings' });
-  await expect(settings).toBeVisible();
-  await expect(settings.getByRole('tab', { name: 'Software Updates' })).toHaveAttribute('aria-selected', 'true');
-  await expect(settings.locator('.updater-status-card').getByText('Software Updates', { exact: true })).toBeVisible();
-  await expect.poll(() => updaterCalls(page)).toMatchObject({ check: 1, download: 0, apply: 0 });
+  await notice.getByRole('button', { name: 'Install and restart' }).click();
+  await expect.poll(() => updaterCalls(page)).toMatchObject({ apply: 1, restart: true });
 
-  await settings.getByRole('button', { name: 'Cancel' }).click();
   await page.reload();
   await dismissOnboarding(page, false);
-  await expect(page.locator('.ant-notification-notice').filter({ hasText: 'is available' })).toHaveCount(0);
-  await expect.poll(() => updaterCalls(page)).toMatchObject({ check: 0, download: 0, apply: 0 });
+  await expect(page.locator('.ant-notification-notice').filter({ hasText: 'ready to install' })).toHaveCount(0);
+  await expect.poll(() => updaterCalls(page)).toMatchObject({ check: 0, status: 0, download: 0, apply: 0 });
+});
+
+test('offers a manual download when automatic downloads are disabled', async ({ page }) => {
+  await installUpdaterStub(page, 'available', false);
+  await dismissOnboarding(page);
+
+  const available = page.locator('.ant-notification-notice').filter({ hasText: 'Quizzer 1.0.0-beta.6 is available' });
+  await expect(available).toHaveCount(1);
+  await expect.poll(() => updaterCalls(page)).toMatchObject({ check: 1, download: 0 });
+  await available.getByRole('button', { name: 'Download update' }).click();
+
+  const ready = page.locator('.ant-notification-notice').filter({ hasText: 'Quizzer 1.0.0-beta.6 is ready to install' });
+  await expect(ready).toHaveCount(1);
+  await expect.poll(() => updaterCalls(page)).toMatchObject({ download: 1, apply: 0 });
 });
 
 test('stays silent when the app is current or the startup check fails', async ({ browser }) => {
@@ -77,7 +123,7 @@ test('stays silent when the app is current or the startup check fails', async ({
     await page.goto('/');
     await page.locator('.app-shell').waitFor();
     await expect.poll(async () => (await updaterCalls(page)).check).toBe(1);
-    await expect(page.locator('.ant-notification-notice').filter({ hasText: 'is available' })).toHaveCount(0);
+    await expect(page.locator('.ant-notification-notice').filter({ hasText: /is available|ready to install/ })).toHaveCount(0);
     await context.close();
   }
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,10 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
 
   return <>
     <GenerationWorker />
-    <UpdateAvailableNotifier onOpenSettings={() => setShowSettingsModal('updates')} />
+    <UpdateAvailableNotifier
+      isTestActive={session?.mode === 'taking'}
+      onOpenSettings={() => setShowSettingsModal('updates')}
+    />
     <Layout className="app-shell">
       {!mobile && session?.mode !== 'taking' && <Sidebar {...sidebarProps} />}
       {mobile && session?.mode !== 'taking' && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     setSession(null);
     setMobileMenuOpen(false);
   }, []);
+  const openUpdateSettings = useCallback(() => setShowSettingsModal('updates'), []);
   const updateKeyboardShortcut = (actionId: ShortcutActionId, shortcut: string) => {
     const changed = changeKeyboardShortcut(keyboardShortcuts, actionId, shortcut);
     if (!changed.ok) {
@@ -152,7 +153,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     <GenerationWorker />
     <UpdateAvailableNotifier
       isTestActive={session?.mode === 'taking'}
-      onOpenSettings={() => setShowSettingsModal('updates')}
+      onOpenSettings={openUpdateSettings}
     />
     <Layout className="app-shell">
       {!mobile && session?.mode !== 'taking' && <Sidebar {...sidebarProps} />}

--- a/src/components/UpdateAvailableNotifier.tsx
+++ b/src/components/UpdateAvailableNotifier.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
-import { App as AntdApp, Button } from 'antd';
+import { App as AntdApp, Button, Space } from 'antd';
 import type { QuizzerDesktopUpdaterApi, UpdaterStatus } from '../types/updater';
 
-const UPDATE_CHECK_SESSION_KEY = 'quizzer.startupUpdateCheck.v1';
+const UPDATE_CHECK_SESSION_KEY = 'quizzer.startupUpdateCheck.v2';
 const UPDATE_NOTIFICATION_KEY = 'quizzer-update-available';
 
 let startupUpdateCheck: Promise<UpdaterStatus | null> | undefined;
@@ -13,38 +13,104 @@ const checkOncePerSession = (updater: QuizzerDesktopUpdaterApi) => {
     if (sessionStorage.getItem(UPDATE_CHECK_SESSION_KEY)) return Promise.resolve(null);
     sessionStorage.setItem(UPDATE_CHECK_SESSION_KEY, 'started');
   } catch { /* The in-memory promise still prevents duplicate checks in restricted storage contexts. */ }
-  startupUpdateCheck = updater.checkForUpdates().catch(() => null);
+
+  startupUpdateCheck = (async () => {
+    const current = await updater.getStatus();
+    if (current.state === 'downloaded') return current;
+    const checked = current.state === 'available' ? current : await updater.checkForUpdates();
+    if (checked.state === 'available' && checked.autoDownload) {
+      return updater.downloadUpdate();
+    }
+    return checked;
+  })().catch(() => null);
   return startupUpdateCheck;
 };
 
 interface Props {
+  isTestActive: boolean;
   onOpenSettings: () => void;
 }
 
-export default function UpdateAvailableNotifier({ onOpenSettings }: Props) {
+export default function UpdateAvailableNotifier({ isTestActive, onOpenSettings }: Props) {
   const { notification } = AntdApp.useApp();
 
   useEffect(() => {
+    if (isTestActive) {
+      notification.destroy(UPDATE_NOTIFICATION_KEY);
+      return;
+    }
     const updater = window.quizzerDesktop?.updater;
     if (!updater) return;
     let active = true;
+
+    const showReadyToInstall = (status: UpdaterStatus) => {
+      if (!status.updateInfo) return;
+      notification.success({
+        key: UPDATE_NOTIFICATION_KEY,
+        role: 'status',
+        duration: 0,
+        placement: 'bottomLeft',
+        message: `Quizzer ${status.updateInfo.version} is ready to install`,
+        description: 'The signed update was downloaded and verified. Quizzer will restart after installation.',
+        actions: <Space>
+          <Button size="small" onClick={onOpenSettings}>Settings</Button>
+          <Button type="primary" size="small" onClick={() => {
+            notification.destroy(UPDATE_NOTIFICATION_KEY);
+            void updater.applyUpdate({ restart: true }).catch(error => {
+              if (!active) return;
+              notification.error({
+                key: UPDATE_NOTIFICATION_KEY,
+                message: 'Quizzer could not install the update',
+                description: error instanceof Error ? error.message : String(error),
+                duration: 0,
+                placement: 'bottomLeft',
+              });
+            });
+          }}>Install and restart</Button>
+        </Space>,
+      });
+    };
+
     void checkOncePerSession(updater).then(status => {
-      if (!active || status?.state !== 'available' || !status.updateInfo) return;
+      if (!active || !status || isTestActive) return;
+      if (status.state === 'downloaded') {
+        showReadyToInstall(status);
+        return;
+      }
+      if (status.state !== 'available' || !status.updateInfo) return;
+
       notification.info({
         key: UPDATE_NOTIFICATION_KEY,
         role: 'status',
         duration: 0,
         placement: 'bottomLeft',
         message: `Quizzer ${status.updateInfo.version} is available`,
-        description: 'Review the signed update in Settings when you are ready. Quizzer will not download or install it automatically.',
-        actions: <Button type="primary" size="small" onClick={() => {
-          notification.destroy(UPDATE_NOTIFICATION_KEY);
-          onOpenSettings();
-        }}>Review update</Button>,
+        description: 'Automatic downloads are off. Download the signed update when you are ready.',
+        actions: <Space>
+          <Button size="small" onClick={onOpenSettings}>Settings</Button>
+          <Button type="primary" size="small" onClick={() => {
+            notification.destroy(UPDATE_NOTIFICATION_KEY);
+            const download = updater.downloadUpdate();
+            startupUpdateCheck = download.catch(() => null);
+            void download.then(downloaded => {
+              if (active && !isTestActive) showReadyToInstall(downloaded);
+            }).catch(error => {
+              if (!active) return;
+              notification.error({
+                key: UPDATE_NOTIFICATION_KEY,
+                message: 'Quizzer could not download the update',
+                description: error instanceof Error ? error.message : String(error),
+                duration: 0,
+                placement: 'bottomLeft',
+              });
+            });
+          }}>Download update</Button>
+        </Space>,
       });
     });
+
     return () => { active = false; };
-  }, [notification, onOpenSettings]);
+  }, [isTestActive, notification, onOpenSettings]);
 
   return null;
 }

--- a/src/components/UpdateAvailableNotifier.tsx
+++ b/src/components/UpdateAvailableNotifier.tsx
@@ -71,8 +71,12 @@ export default function UpdateAvailableNotifier({ isTestActive, onOpenSettings }
       });
     };
 
-    void checkOncePerSession(updater).then(status => {
-      if (!active || !status || isTestActive) return;
+    void checkOncePerSession(updater).then(async cachedStatus => {
+      if (!active || !cachedStatus || isTestActive) return;
+      const status = cachedStatus.state === 'available'
+        ? await updater.getStatus().catch(() => cachedStatus)
+        : cachedStatus;
+      if (!active || isTestActive) return;
       if (status.state === 'downloaded') {
         showReadyToInstall(status);
         return;

--- a/src/components/UpdaterStatus.tsx
+++ b/src/components/UpdaterStatus.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Alert, Button, Card, Descriptions, Divider, Progress, Radio, Space, Tag, Typography } from 'antd';
+import { Alert, Button, Card, Descriptions, Divider, Progress, Radio, Space, Switch, Tag, Typography } from 'antd';
 import { formatErrorMessage } from '../utils/errorFormatting';
 import { ErrorDisplay } from './ErrorDisplay';
 import {
@@ -58,12 +58,19 @@ export default function UpdaterStatusView() {
     if (!window.quizzerDesktop?.updater) return;
     setLoading(true);
     try {
-      const next = await window.quizzerDesktop.updater.checkForUpdates({
+      let next = await window.quizzerDesktop.updater.checkForUpdates({
         channel: channelOverride || status?.channel,
       });
       setStatus(next);
       if (next.state === 'available') {
-        message.info(`Update ${next.updateInfo?.version} is available`);
+        if (next.autoDownload) {
+          setDownloading(true);
+          next = await window.quizzerDesktop.updater.downloadUpdate();
+          setStatus(next);
+          message.success(`Update ${next.updateInfo?.version} downloaded and verified`);
+        } else {
+          message.info(`Update ${next.updateInfo?.version} is available`);
+        }
       } else if (next.state === 'up-to-date') {
         message.success('Quizzer is up to date');
       } else if (next.state === 'error') {
@@ -73,6 +80,7 @@ export default function UpdaterStatusView() {
       message.error(formatErrorMessage(err, 'updater'));
     } finally {
       setLoading(false);
+      setDownloading(false);
     }
   };
 
@@ -96,11 +104,30 @@ export default function UpdaterStatusView() {
     }
   };
 
+  const handleAutoDownloadChange = async (enabled: boolean) => {
+    if (!window.quizzerDesktop?.updater) return;
+    try {
+      let next = await window.quizzerDesktop.updater.setAutoDownload(enabled);
+      setStatus(next);
+      if (enabled && next.state === 'available') {
+        setDownloading(true);
+        next = await window.quizzerDesktop.updater.downloadUpdate();
+        setStatus(next);
+        message.success('Automatic downloads enabled; update downloaded and verified');
+      }
+    } catch (err) {
+      message.error(formatErrorMessage(err, 'updater'));
+      await refreshStatus();
+    } finally {
+      setDownloading(false);
+    }
+  };
+
   const handleApply = async () => {
     if (!window.quizzerDesktop?.updater) return;
     setApplying(true);
     try {
-      const result = await window.quizzerDesktop.updater.applyUpdate();
+      const result = await window.quizzerDesktop.updater.applyUpdate({ restart: true });
       setStatus(result.status);
       message.success(result.message || 'Verified staged package — installer handoff pending');
     } catch (err) {
@@ -215,6 +242,19 @@ export default function UpdaterStatusView() {
           </Space>
         </div>
 
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16 }}>
+          <div>
+            <Typography.Text>Download updates automatically</Typography.Text>
+            <div><Typography.Text type="secondary" style={{ fontSize: 12 }}>Quizzer still waits for you to install and restart.</Typography.Text></div>
+          </div>
+          <Switch
+            aria-label="Download updates automatically"
+            checked={status?.autoDownload ?? true}
+            onChange={enabled => void handleAutoDownloadChange(enabled)}
+            disabled={!status || loading || downloading || applying || discarding || rollingBack}
+          />
+        </div>
+
         {/* State Alerts & Actions */}
         {state === 'available' && status?.updateInfo && (
           <Alert
@@ -262,7 +302,7 @@ export default function UpdaterStatusView() {
             description={
               <Space direction="vertical" size="small" style={{ width: '100%', marginTop: 8 }}>
                 <Typography.Text type="secondary">
-                  SHA-256 and Ed25519 signature verified in scoped staging. Ready to verify host package and stage for installer handoff.
+                  SHA-256 and Ed25519 signature verified in private staging. Install now to replace Quizzer and restart automatically.
                 </Typography.Text>
                 <Space>
                   <Button
@@ -272,7 +312,7 @@ export default function UpdaterStatusView() {
                     onClick={() => void handleApply()}
                     loading={applying}
                   >
-                    Verify staged package
+                    Install and restart
                   </Button>
                   <Button
                     size="small"
@@ -293,11 +333,11 @@ export default function UpdaterStatusView() {
             type="success"
             showIcon
             icon={<CheckCircleOutlined />}
-            message="Installer handoff successful"
+            message="Update installation started"
             description={
               <Space direction="vertical" size="small" style={{ width: '100%', marginTop: 8 }}>
                 <Typography.Text type="secondary">
-                  The update package has been downloaded, cryptographically verified, and handed off to the system installer. Complete the installation in the system window that opened.
+                  Quizzer is closing to install the verified update and restart. On platforms that use a system installer, follow its prompts.
                 </Typography.Text>
                 <Button
                   size="small"
@@ -385,13 +425,13 @@ export default function UpdaterStatusView() {
             )}
           </Descriptions.Item>
           <Descriptions.Item label="Safety guarantee">
-            All updates are cryptographically verified with Ed25519 signatures and SHA-256 digests in scoped staging before handoff. In-place binary replacement without an explicit platform adapter is never executed.
+            All updates are cryptographically verified with Ed25519 signatures and SHA-256 digests in private staging. The macOS adapter also validates the application bundle identity and version before replacement.
           </Descriptions.Item>
           <Descriptions.Item label="Runtime mode">
             {status?.mechanism === 'manual-handoff'
               ? 'Packaged desktop application (verified staging; manual installation required)'
               : status?.mechanism === 'staged-ready'
-                ? 'Packaged desktop application (verified staging; platform handoff enabled)'
+                ? 'Packaged desktop application (verified staging; install and restart enabled)'
                 : 'Development mode (verified staging; binary replacement simulated)'}
           </Descriptions.Item>
         </Descriptions>

--- a/src/types/updater.ts
+++ b/src/types/updater.ts
@@ -66,6 +66,7 @@ export interface UpdaterStatus {
   state: UpdateState;
   currentVersion: string;
   channel: UpdateChannel;
+  autoDownload: boolean;
   target: UpdateTarget;
   keyStatus: KeyStatus;
   mechanism: 'staged-ready' | 'staged-development' | 'manual-handoff';
@@ -115,6 +116,7 @@ export interface QuizzerDesktopUpdaterApi {
   getStatus: () => Promise<UpdaterStatus>;
   checkForUpdates: (options?: CheckUpdateOptions) => Promise<UpdaterStatus>;
   downloadUpdate: () => Promise<UpdaterStatus>;
+  setAutoDownload: (enabled: boolean) => Promise<UpdaterStatus>;
   applyUpdate: (options?: ApplyUpdateOptions) => Promise<ApplyUpdateResult>;
   discardUpdate: () => Promise<DiscardUpdateResult>;
   rollbackUpdate: () => Promise<RollbackResult>;

--- a/test/desktop-macos-update.test.mjs
+++ b/test/desktop-macos-update.test.mjs
@@ -79,13 +79,17 @@ test('prepares a verified DMG bundle with fixed native commands and a non-app st
     assert.doesNotMatch(plan.args[4], /\.app$/);
     assert.equal((await readFile(plan.args[0], 'utf8')), macosUpdateHelperSource());
 
-    assert.deepEqual(calls.map(call => [call.command, call.args[0]]), [
-      ['/usr/bin/hdiutil', 'attach'],
-      ['/usr/libexec/PlistBuddy', '-c'],
-      ['/usr/libexec/PlistBuddy', '-c'],
-      ['/usr/bin/ditto', '--noqtn'],
-      ['/usr/bin/hdiutil', 'detach'],
+    assert.deepEqual(calls.map(call => call.command), [
+      '/usr/bin/hdiutil',
+      '/usr/libexec/PlistBuddy',
+      '/usr/libexec/PlistBuddy',
+      '/usr/bin/ditto',
+      '/usr/bin/hdiutil',
     ]);
+    assert.equal(calls[0].args[0], 'attach');
+    assert.match(calls[3].args[0], /\/mount\/Quizzer\.app$/);
+    assert.match(calls[3].args[1], /\/Quizzer\.next$/);
+    assert.equal(calls[4].args[0], 'detach');
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/test/desktop-macos-update.test.mjs
+++ b/test/desktop-macos-update.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  INSTALLED_APPLICATION_PATH,
+  macosUpdateHelperSource,
+  prepareMacosDmgUpdate,
+  validateInstalledApplicationPath,
+} from '../desktop/macos-update.mjs';
+
+test('macOS automatic replacement accepts only the installed Applications bundle by default', () => {
+  assert.equal(validateInstalledApplicationPath('/Applications/Quizzer.app'), INSTALLED_APPLICATION_PATH);
+  assert.throws(
+    () => validateInstalledApplicationPath('/Users/example/Applications/Quizzer.app'),
+    /require Quizzer to run from \/Applications\/Quizzer\.app/,
+  );
+  assert.throws(
+    () => validateInstalledApplicationPath('/tmp/Quizzer.app'),
+    /require Quizzer to run from \/Applications\/Quizzer\.app/,
+  );
+});
+
+test('macOS replacement helper keeps backups out of Spotlight and restores on relaunch failure', () => {
+  const source = macosUpdateHelperSource();
+  assert.match(source, /Quizzer did not exit before the update timeout/);
+  assert.match(source, /\/usr\/bin\/open -n "\$target_app"/);
+  assert.match(source, /\/bin\/mv "\$previous_app" "\$target_app"/);
+  assert.match(source, /\/bin\/rm -rf "\$staging_dir"[\s\S]+\/usr\/bin\/open/);
+  assert.doesNotMatch(source, /previous[^\n]*\.app/);
+});
+
+test('prepares a verified DMG bundle with fixed native commands and a non-app staging name', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'quizzer-macos-update-test-'));
+  const installedApp = join(directory, 'Applications', 'Quizzer.app');
+  const userDataDir = join(directory, 'user-data');
+  const stagingDirectory = join(userDataDir, 'updates', 'staging');
+  const dmgPath = join(stagingDirectory, 'Quizzer.dmg');
+  const calls = [];
+
+  await mkdir(join(installedApp, 'Contents'), { recursive: true });
+  await mkdir(stagingDirectory, { recursive: true });
+  await writeFile(dmgPath, 'verified dmg bytes');
+
+  const runner = async (command, args) => {
+    calls.push({ command, args });
+    if (command === '/usr/bin/hdiutil' && args[0] === 'attach') {
+      const mountDirectory = args[args.indexOf('-mountpoint') + 1];
+      await mkdir(join(mountDirectory, 'Quizzer.app', 'Contents'), { recursive: true });
+      await writeFile(join(mountDirectory, 'Quizzer.app', 'Contents', 'Info.plist'), 'test plist');
+    }
+    if (command === '/usr/libexec/PlistBuddy') {
+      return { stdout: args[1].includes('CFBundleIdentifier') ? 'dev.quizzer.app\n' : '1.2.0\n', stderr: '' };
+    }
+    if (command === '/usr/bin/ditto') {
+      await mkdir(args.at(-1), { recursive: true });
+    }
+    return { stdout: '', stderr: '' };
+  };
+
+  try {
+    const plan = await prepareMacosDmgUpdate({
+      dmgPath,
+      userDataDir,
+      applicationPath: installedApp,
+      requiredApplicationPath: installedApp,
+      currentPid: 1234,
+      targetVersion: '1.2.0',
+      runner,
+    });
+
+    assert.equal(plan.command, '/bin/sh');
+    assert.equal(plan.args[1], '1234');
+    assert.equal(plan.args[2], installedApp);
+    assert.match(plan.args[3], /\/Quizzer\.next$/);
+    assert.match(plan.args[4], /\/Quizzer\.previous$/);
+    assert.doesNotMatch(plan.args[3], /\.app$/);
+    assert.doesNotMatch(plan.args[4], /\.app$/);
+    assert.equal((await readFile(plan.args[0], 'utf8')), macosUpdateHelperSource());
+
+    assert.deepEqual(calls.map(call => [call.command, call.args[0]]), [
+      ['/usr/bin/hdiutil', 'attach'],
+      ['/usr/libexec/PlistBuddy', '-c'],
+      ['/usr/libexec/PlistBuddy', '-c'],
+      ['/usr/bin/ditto', '--noqtn'],
+      ['/usr/bin/hdiutil', 'detach'],
+    ]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/test/desktop-updater-ipc.test.mjs
+++ b/test/desktop-updater-ipc.test.mjs
@@ -4,10 +4,18 @@ import test from 'node:test';
 import { isTrustedRendererUrl } from '../desktop/security.mjs';
 
 import {
+  validateAutoDownloadPreference,
   validateUpdaterApplyOptions,
   validateUpdaterChannel,
   validateUpdaterCheckOptions,
 } from '../desktop/updater-ipc.mjs';
+
+test('updater IPC auto-download preference accepts only booleans', () => {
+  assert.equal(validateAutoDownloadPreference(true), true);
+  assert.equal(validateAutoDownloadPreference(false), false);
+  assert.throws(() => validateAutoDownloadPreference('false'), /autoDownload must be a boolean/);
+  assert.throws(() => validateAutoDownloadPreference(null), /autoDownload must be a boolean/);
+});
 
 test('renderer origin verification rejects untrusted origins from accessing updater IPC', () => {
   assert.equal(isTrustedRendererUrl('quizzer://app/'), true);
@@ -78,6 +86,7 @@ test('preload script exports only frozen, context-isolated updater surface', asy
   assert.match(preloadSource, /ipcRenderer\.invoke\('updater:status'\)/);
   assert.match(preloadSource, /ipcRenderer\.invoke\('updater:check'/);
   assert.match(preloadSource, /ipcRenderer\.invoke\('updater:download'\)/);
+  assert.match(preloadSource, /ipcRenderer\.invoke\('updater:set-auto-download'/);
   assert.match(preloadSource, /ipcRenderer\.invoke\('updater:apply'/);
   assert.match(preloadSource, /ipcRenderer\.invoke\('updater:rollback'\)/);
 

--- a/test/desktop-updater-rollback.test.mjs
+++ b/test/desktop-updater-rollback.test.mjs
@@ -641,7 +641,7 @@ test('applyUpdate in packaged mode reports staged-ready mechanism, handoffPendin
     assert.equal(result.handoffPending, true);
     assert.equal(result.mechanism, 'staged-ready');
     assert.equal(result.restartRequested, true);
-    assert.match(result.message, /handed off to system installer/i);
+    assert.match(result.message, /install it and restart/i);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/test/desktop-updater-state.test.mjs
+++ b/test/desktop-updater-state.test.mjs
@@ -200,6 +200,23 @@ test('channel selection persists in userData atomically and survives restart', a
   }
 });
 
+test('automatic downloads default on and the user preference persists across restart', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'quizzer-auto-download-test-'));
+  try {
+    const updater = new DesktopUpdater({ userDataDir: directory, currentVersion: '1.0.0' });
+    assert.equal((await updater.getStatus()).autoDownload, true);
+
+    const disabled = await updater.setAutoDownload(false);
+    assert.equal(disabled.autoDownload, false);
+
+    const restarted = new DesktopUpdater({ userDataDir: directory, currentVersion: '1.0.0' });
+    assert.equal((await restarted.getStatus()).autoDownload, false);
+    await assert.rejects(updater.setAutoDownload('yes'), /autoDownload must be a boolean/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test('verified staged update is recovered and remains applicable after restart', async () => {
   const env = await setupTestEnv('1.2.0');
   try {

--- a/test/desktop-updater-target.test.mjs
+++ b/test/desktop-updater-target.test.mjs
@@ -109,7 +109,7 @@ test('selectTargetArtifact filters for matching OS and architecture, excluding C
     },
   ];
 
-  // macOS arm64 prefers pkg, then dmg, then zip (handoff-capable formats first)
+  // macOS arm64 prefers DMG because Quizzer can replace and restart itself from it.
   const macArm = selectTargetArtifact(artifacts, { platform: 'macos', architecture: 'arm64' });
   assert.equal(macArm.format, 'dmg');
   assert.equal(macArm.name, 'quizzer-1.0.0-macos-arm64.dmg');


### PR DESCRIPTION
## Summary

- download signed updates automatically by default, with a persistent setting to opt into manual downloads
- defer install reminders while a quiz is in progress, then offer one Install and restart action
- replace the verified macOS app in /Applications after validating the DMG bundle identity and signed target version
- stage replacement and rollback bundles without an .app suffix so Spotlight does not show duplicate Quizzer applications
- restore the previous application if replacement or relaunch fails

## Verification

- npm test (411 passed)
- npm run lint
- npm run build
- npx playwright test e2e/update-notification.spec.ts (3 passed)
- npm run test:e2e:electron (2 passed)
- visual browser smoke test: populated page, no console errors, no Vite error overlay