### PR TITLE
Remove the default Electron application menu

### DIFF
--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -315,6 +315,10 @@ const createTray = () => {
 };
 
 app.whenReady().then(async () => {
+  // Quizzer exposes its supported navigation inside the application. Removing
+  // Electron's default menu also prevents production users from invoking
+  // renderer reload, zoom, and developer-tool actions.
+  Menu.setApplicationMenu(null);
   credentialVault = new CredentialVault(join(app.getPath('userData'), 'credentials.json'), safeStorage);
   desktopUpdater = new DesktopUpdater({
     userDataDir: app.getPath('userData'),

--- a/test/desktop-application-menu.test.mjs
+++ b/test/desktop-application-menu.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('desktop startup removes the default Electron application menu', async () => {
+  const source = await readFile(new URL('../desktop/main.mjs', import.meta.url), 'utf8');
+  const readyIndex = source.indexOf('app.whenReady().then');
+  const menuIndex = source.indexOf('Menu.setApplicationMenu(null)', readyIndex);
+  const windowIndex = source.indexOf('createWindow()', readyIndex);
+
+  assert.notEqual(readyIndex, -1);
+  assert.ok(menuIndex > readyIndex, 'application menu should be removed during ready startup');
+  assert.ok(windowIndex > menuIndex, 'application menu should be removed before the window is created');
+});


### PR DESCRIPTION
Closes #56

Removes the unsupported default Electron menu before the Quizzer window is created, preventing production access to reload, zoom, fullscreen, and developer-tool commands. The tray menu remains available for showing or quitting Quizzer.

Verification:
- node --test test/desktop-application-menu.test.mjs
- npm run lint -- --quiet