### PR TITLE
Keep modal scrolling inside the app viewport

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,6 +1,21 @@
 import { test, expect } from '@playwright/test';
 import { dismissOnboarding, setInterfaceMode } from './helpers';
 
+test('opening Settings keeps scrolling inside the modal and app panes', async ({ page }) => {
+  await dismissOnboarding(page);
+
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+,' : 'Control+,');
+  await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible();
+
+  const viewportDoesNotScroll = await page.evaluate(() => {
+    const scrollingElement = document.scrollingElement;
+    if (!scrollingElement) return false;
+    return scrollingElement.scrollHeight === scrollingElement.clientHeight
+      && getComputedStyle(document.body).overflow === 'hidden';
+  });
+  expect(viewportDoesNotScroll).toBe(true);
+});
+
 test('Settings search/reset and keyboard accessibility', async ({ page }) => {
   await dismissOnboarding(page);
 

--- a/src/index.css
+++ b/src/index.css
@@ -31,7 +31,7 @@
 }
 
 * { box-sizing: border-box; }
-html, body, #root { width: 100%; min-width: 320px; min-height: 100%; margin: 0; }
+html, body, #root { width: 100%; min-width: 320px; height: 100%; margin: 0; overflow: hidden; }
 body { background: var(--page); color: var(--text); }
 button, input, textarea, select { font: inherit; }
 


### PR DESCRIPTION
Closes #57

- lock the document root to the application viewport
- keep scrolling inside app and modal content areas
- cover Settings with a viewport overflow regression test