### PR TITLE
Make test source documents directly clickable

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -169,6 +169,8 @@ test('resumes real onboarding and finishes through durable quiz practice', async
 
   await expect(page.getByRole('heading', { name: 'Try one question' })).toBeVisible();
   await page.getByRole('button', { name: 'Open coordination quiz' }).click();
+  await expect(page.locator('.test-source-item')).toHaveRole('button');
+  await expect(page.getByRole('button', { name: 'Open document' })).toHaveCount(0);
   await page.locator('.ant-radio-button-wrapper').filter({ hasText: 'Practice mode' }).click();
   await page.getByRole('button', { name: 'Start Practice' }).click();
   await expect(page.getByRole('heading', { name: 'Question 1' })).toBeVisible();

--- a/src/components/TestStart.tsx
+++ b/src/components/TestStart.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Typography, Checkbox, InputNumber, Popconfirm, Radio, Space, Tag } from 'antd';
-import { FileTextOutlined, LinkOutlined } from '@ant-design/icons';
+import { FileTextOutlined } from '@ant-design/icons';
 import type { StoredTest, StoredTestDraft } from '../db/db';
 import { useState } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
@@ -68,17 +68,19 @@ const TestStart: React.FC<Props> = ({ test, draft, onStart, onResume, onOpenDocu
         {documentIds.length ? <div className="test-source-list">
           {documentIds.map((documentId, index) => {
             const document = sourceDocuments?.[index];
-            return <div className="test-source-item" key={documentId}>
-              <div>
+            const content = <>
+              <span className="test-source-copy">
                 <Typography.Text strong>{document?.name ?? (sourceDocuments ? 'Deleted document' : 'Loading source…')}</Typography.Text>
-                <div className="test-source-meta">
+                <span className="test-source-meta">
                   {document?.pageCount && <Tag>{document.pageCount} pages</Tag>}
                   {document?.tags.map(tag => <Tag key={tag}>{tag}</Tag>)}
                   {!document && sourceDocuments && <Tag color="error">No longer in library</Tag>}
-                </div>
-              </div>
-              {document && <Button type="link" icon={<LinkOutlined />} onClick={() => onOpenDocument(document.id)}>Open document</Button>}
-            </div>;
+                </span>
+              </span>
+            </>;
+            return document
+              ? <button type="button" className="test-source-item" key={documentId} onClick={() => onOpenDocument(document.id)}>{content}</button>
+              : <div className="test-source-item is-unavailable" key={documentId}>{content}</div>;
           })}
         </div> : <Alert type="info" showIcon message="Source information is unavailable"
           description="This test was created before Quizzer recorded document origins, or it was imported without source metadata." />}

--- a/src/index.css
+++ b/src/index.css
@@ -228,10 +228,11 @@ button, input, textarea, select { font: inherit; }
 .test-source-sidebar { height: 100%; min-height: 0; padding: 20px 0 32px 20px; border-left: 1px solid var(--border); background: var(--surface-soft); display: flex; flex-direction: column; overflow: hidden; text-align: left; }
 .test-source-title { margin: 0 4px 16px !important; flex: 0 0 auto; }
 .test-source-list { min-height: 0; display: grid; align-content: start; gap: 4px; overflow-y: auto; }
-.test-source-item { display: grid; min-width: 0; gap: 7px; padding: 10px 4px; }
+.test-source-item { display: block; width: 100%; min-width: 0; padding: 10px 8px; border: 0; border-radius: 8px; color: inherit; background: transparent; text-align: left; }
+.test-source-item:not(.is-unavailable) { cursor: pointer; }
+.test-source-item:not(.is-unavailable):hover, .test-source-item:not(.is-unavailable):focus-visible { background: var(--selected); outline: 2px solid #1677ff; outline-offset: -2px; }
 .test-source-item + .test-source-item { border-top: 1px solid var(--border); }
-.test-source-item > div:first-child { min-width: 0; }
-.test-source-item .ant-btn { width: fit-content; height: auto; padding: 0; }
+.test-source-copy { display: grid; min-width: 0; gap: 7px; }
 .test-source-meta { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 5px; }
 .test-timer-control { display: flex; align-items: center; margin-bottom: 20px; }
 .test-start-button { width: 150px; height: 48px; padding-inline: 36px; border-radius: 24px; font-size: 16px; }


### PR DESCRIPTION
Closes #59

- turn available source rows into accessible buttons
- remove the redundant Open document action
- add hover and keyboard focus states
- cover the source row semantics in the onboarding flow