### PR TITLE
Show readable grounding source labels

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -185,7 +185,10 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await page.getByRole('button', { name: /Check answer/ }).click();
   await expect(page.getByRole('button', { name: /Ask AI about this answer/ })).toBeVisible();
   await expect(page.locator('[data-onboarding-target="practice-feedback"]').filter({ visible: true }).first()).toBeVisible();
-  await expect(page.locator('[data-onboarding-target="citations"]').filter({ visible: true }).first()).toBeVisible();
+  const groundingSources = page.getByRole('region', { name: 'Grounding sources' });
+  await expect(groundingSources).toBeVisible();
+  await expect(groundingSources.getByText('coordination', { exact: true })).toHaveCount(1);
+  await expect(groundingSources.locator('code')).toHaveCount(0);
   await expect(page.locator('[data-onboarding-target="ask-ai"]').filter({ visible: true }).first()).toBeVisible();
   await page.getByRole('button', { name: 'Pause' }).click();
 

--- a/src/components/QuestionCitations.tsx
+++ b/src/components/QuestionCitations.tsx
@@ -13,20 +13,25 @@ export default function QuestionCitations({ provenance }: Props) {
   const documents = useLiveQuery(async (): Promise<(StoredDocument | undefined)[]> =>
     provenance?.documentIds.length ? db.documents.bulkGet(provenance.documentIds) : [], [documentKey]) ?? [];
   if (!provenance?.sourceSpanIds.length) return null;
-  const names = new Map(documents.flatMap(document => document ? [[document.id, document.name] as const] : []));
+  const documentById = new Map(documents.flatMap(document => document ? [[document.id, document] as const] : []));
+  const seen = new Set<string>();
+  const sources = provenance.sourceSpanIds.flatMap(spanId => {
+    const documentId = provenance.documentIds.find(id => spanId === id || spanId.startsWith(`${id}:`));
+    const document = documentId ? documentById.get(documentId) : undefined;
+    const localSpanId = documentId && spanId.startsWith(`${documentId}:`) ? spanId.slice(documentId.length + 1) : spanId;
+    const chunk = document?.chunks?.find(item => item.id === spanId || item.id === localSpanId);
+    const key = `${documentId ?? spanId}:${chunk?.page ?? 'document'}`;
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [{ key, label: `${document?.name ?? 'Source document'}${chunk?.page ? ` · page ${chunk.page}` : ''}` }];
+  });
   return <section data-onboarding-target="citations" className="question-citations" aria-label="Grounding sources">
     <Space><DatabaseOutlined /><Typography.Text strong>Grounding sources</Typography.Text></Space>
     <Typography.Paragraph type="secondary">
-      These stable source spans were used to generate this question.
+      These documents were used to generate this question.
     </Typography.Paragraph>
     <ul>
-      {provenance.sourceSpanIds.map(spanId => {
-        const documentId = provenance.documentIds.find(id => spanId.startsWith(`${id}:`));
-        return <li key={spanId}>
-          <Typography.Text>{documentId ? names.get(documentId) ?? documentId : 'Source'}</Typography.Text>
-          <Typography.Text code copyable={{ text: spanId }}>{spanId}</Typography.Text>
-        </li>;
-      })}
+      {sources.map(source => <li key={source.key}><Typography.Text>{source.label}</Typography.Text></li>)}
     </ul>
   </section>;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -180,9 +180,7 @@ button, input, textarea, select { font: inherit; }
 .question-citations { width: 100%; margin-top: 20px; padding: 14px 16px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
 .question-citations p { margin: 4px 0 8px; }
 .question-citations ul { margin: 0; padding-left: 20px; }
-.question-citations li { display: grid; grid-template-columns: minmax(120px, 0.35fr) minmax(0, 1fr); gap: 10px; align-items: baseline; margin-top: 6px; }
-.question-citations code { overflow-wrap: anywhere; white-space: normal; }
-@media (max-width: 640px) { .question-citations li { grid-template-columns: 1fr; gap: 2px; } }
+.question-citations li { margin-top: 6px; }
 .ai-chat-shell { display: flex; min-height: min(680px, 78vh); flex-direction: column; gap: 12px; }
 .ai-chat-toolbar { display: grid; gap: 10px; }
 .ai-chat-scope { display: flex; align-items: center; gap: 10px; padding: 11px 13px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-soft); }


### PR DESCRIPTION
Closes #60

- replace internal source-span IDs with document names and page numbers
- collapse duplicate references to the same document page
- cover the practice citation display in the onboarding flow