### PR TITLE
Keep Prompt Studio inside Settings

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -40,3 +40,10 @@ export async function setInterfaceMode(page: Page, mode: 'simple' | 'advanced') 
   }
   await expect(dialog).toBeHidden();
 }
+
+export async function openPromptStudio(page: Page) {
+  await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Settings' });
+  await dialog.getByRole('tab', { name: 'Prompt Studio' }).click();
+  return dialog;
+}

--- a/e2e/offline-recovery.spec.ts
+++ b/e2e/offline-recovery.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { dismissOnboarding, setInterfaceMode } from './helpers';
+import { dismissOnboarding, openPromptStudio, setInterfaceMode } from './helpers';
 
 const pendingBrowserChanges = (page: import('@playwright/test').Page) => page.evaluate(async () => {
   const database = await new Promise<IDBDatabase>((resolve, reject) => {
@@ -22,7 +22,7 @@ test('keeps an offline prompt edit locally and publishes it after reconnect', as
   const profileName = `Offline recovery ${testInfo.workerIndex}-${Date.now()}`;
   await dismissOnboarding(page);
   await setInterfaceMode(page, 'advanced');
-  await page.getByRole('button', { name: 'Prompt Studio' }).click();
+  await openPromptStudio(page);
 
   await context.setOffline(true);
   await page.getByRole('button', { name: 'Clone selected' }).click();
@@ -42,7 +42,7 @@ test('keeps an offline prompt edit locally and publishes it after reconnect', as
     const verificationPage = await verificationContext.newPage();
     await dismissOnboarding(verificationPage);
     await setInterfaceMode(verificationPage, 'advanced');
-    await verificationPage.getByRole('button', { name: 'Prompt Studio' }).click();
+    await openPromptStudio(verificationPage);
     await expect(verificationPage.getByRole('button', { name: profileName, exact: false })).toBeVisible();
   } finally {
     await verificationContext.close();

--- a/e2e/prompt-studio.spec.ts
+++ b/e2e/prompt-studio.spec.ts
@@ -1,14 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { dismissOnboarding, setInterfaceMode } from './helpers';
+import { dismissOnboarding, openPromptStudio, setInterfaceMode } from './helpers';
 import { readFileSync } from 'node:fs';
 
 test('Prompt Studio clone/edit/validate plus import/export', async ({ page }) => {
   await dismissOnboarding(page);
 
   await setInterfaceMode(page, 'advanced');
-  await page.getByRole('button', { name: 'Prompt Studio' }).click();
-
-  const studio = page.getByRole('dialog', { name: 'Settings' });
+  const studio = await openPromptStudio(page);
   await expect(studio.getByRole('tab', { name: 'Prompt Studio' })).toHaveAttribute('aria-selected', 'true');
   await expect(studio.getByRole('button', { name: 'Reset to selected profile' })).toHaveCount(0);
   await expect(studio.getByRole('button', { name: 'Save changes' })).toHaveCount(0);

--- a/e2e/simple-advanced.spec.ts
+++ b/e2e/simple-advanced.spec.ts
@@ -1,21 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { dismissOnboarding, setInterfaceMode } from './helpers';
+import { dismissOnboarding, openPromptStudio, setInterfaceMode } from './helpers';
 
 test('immediate reversible Simple/Advanced disclosure with stored data retained', async ({ page }) => {
   await dismissOnboarding(page);
   await setInterfaceMode(page, 'simple');
 
-  const studioButton = page.getByRole('button', { name: 'Prompt Studio' });
+  const studioButton = page.locator('.sidebar-footer').getByRole('button', { name: 'Prompt Studio' });
   await expect(page.getByRole('button', { name: 'Switch to Advanced mode' })).toHaveCount(0);
   await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
   const simpleSettings = page.getByRole('dialog', { name: 'Settings' });
   await expect(simpleSettings.getByRole('tab', { name: 'Prompt Studio' })).toHaveCount(0);
   await simpleSettings.getByRole('button', { name: 'Cancel' }).click();
   await setInterfaceMode(page, 'advanced');
-  await expect(studioButton).toBeVisible();
+  await expect(studioButton).toHaveCount(0);
   await expect(page.getByText('System health', { exact: true })).toBeVisible();
 
-  await studioButton.click();
+  await openPromptStudio(page);
   await page.getByRole('button', { name: 'Clone selected' }).click();
   await page.getByLabel('Prompt profile name').fill('Mode-safe profile');
   await page.getByRole('button', { name: 'Save new version' }).click();
@@ -31,7 +31,7 @@ test('immediate reversible Simple/Advanced disclosure with stored data retained'
   await expect(studioButton).toBeHidden();
 
   await setInterfaceMode(page, 'advanced');
-  await studioButton.click();
+  await openPromptStudio(page);
   await expect(page.getByRole('button', { name: 'Mode-safe profile' }).first()).toBeVisible();
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,6 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     onAddDocument: () => { setShowDocumentModal(true); setMobileMenuOpen(false); },
     onOpenPlugins: () => { setShowPluginsModal(true); setMobileMenuOpen(false); },
     onOpenSettings: () => { setShowSettingsModal(true); setMobileMenuOpen(false); },
-    onOpenPromptStudio: () => { setShowSettingsModal('prompts'); setMobileMenuOpen(false); },
     onOpenGeneration: () => { setShowGenerationCenter(true); setMobileMenuOpen(false); },
     onOpenHome: () => select(null),
     onOpenTutorial: () => { setShowOnboarding(true); setMobileMenuOpen(false); },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Badge, Button, Empty, Input, Layout, List, Popconfirm, Space, Tabs, Tag, Typography } from 'antd';
-import { ApiOutlined, DeleteOutlined, ExperimentOutlined, FileTextOutlined, FormOutlined, HomeOutlined, PlusOutlined, QuestionCircleOutlined, SearchOutlined, SettingOutlined, SyncOutlined } from '@ant-design/icons';
+import { ApiOutlined, DeleteOutlined, FileTextOutlined, FormOutlined, HomeOutlined, PlusOutlined, QuestionCircleOutlined, SearchOutlined, SettingOutlined, SyncOutlined } from '@ant-design/icons';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db, type StoredAppProfile } from '../db/db';
 import { getMessageApi } from '../utils/messageProvider';
@@ -15,7 +15,6 @@ interface Props {
   onAddDocument: () => void;
   onOpenPlugins: () => void;
   onOpenSettings: () => void;
-  onOpenPromptStudio: () => void;
   onOpenGeneration: () => void;
   onOpenHome: () => void;
   onOpenTutorial: () => void;
@@ -24,7 +23,7 @@ interface Props {
   embedded?: boolean;
 }
 
-export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument, onOpenPlugins, onOpenSettings, onOpenPromptStudio, onOpenGeneration, onOpenHome, onOpenTutorial, profile, dark, embedded = false }: Props) {
+export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument, onOpenPlugins, onOpenSettings, onOpenGeneration, onOpenHome, onOpenTutorial, profile, dark, embedded = false }: Props) {
   const tests = useLiveQuery(() => db.tests.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const documents = useLiveQuery(() => db.documents.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const [tab, setTab] = useState<'tests' | 'documents'>(selection?.kind === 'document' ? 'documents' : 'tests');
@@ -123,7 +122,6 @@ export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument,
         </Button>
         <Button data-onboarding-target="provider" type="text" icon={<ApiOutlined />} onClick={onOpenPlugins}>Plugins & models</Button>
         <Button type="text" icon={<SettingOutlined />} onClick={onOpenSettings}>Settings</Button>
-        {profile?.interfaceMode === 'advanced' && <Button type="text" icon={<ExperimentOutlined />} onClick={onOpenPromptStudio}>Prompt Studio</Button>}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #58

- remove the separate Prompt Studio sidebar button
- retain Prompt Studio as an Advanced Settings tab
- update browser coverage to enter Prompt Studio through Settings