### PR TITLE
Replace sidebar Home with contextual back navigation

### DIFF
--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -8,8 +8,8 @@ test('exposes semantic main navigation and keyboard-accessible settings after on
 
   const navigation = page.locator('.desktop-sidebar');
   await expect(navigation).toBeVisible();
+  await expect(navigation.locator('button').filter({ hasText: 'Home' })).toHaveCount(0);
   const navigationItems = [
-    navigation.locator('button').filter({ hasText: 'Home' }),
     navigation.locator('[role="tab"]').filter({ hasText: 'Documents' }),
     navigation.locator('[role="tab"]').filter({ hasText: 'Tests' }),
     navigation.locator('button').filter({ hasText: 'Activity' }),

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -16,7 +16,7 @@ export async function dismissOnboarding(page: Page, navigate = true) {
       await expect(onboarding).toBeHidden();
     }
     await pause.click();
-    await page.getByRole('button', { name: 'Home' }).click();
+    await page.getByRole('button', { name: 'Back to home' }).click();
   }
   await expect(welcome).toBeVisible();
 

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -215,7 +215,7 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await expect(page.getByRole('heading', { name: 'Question 1' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Learn from your own material' })).toHaveCount(0);
   await page.getByRole('button', { name: 'Pause' }).click();
-  await page.getByRole('button', { name: 'Home' }).click();
+  await page.getByRole('button', { name: 'Back to home' }).click();
   await expect(page.getByRole('heading', { name: 'Welcome to Quizzer' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Resume setup' })).toHaveCount(0);
 

--- a/e2e/readme-screenshots.capture.ts
+++ b/e2e/readme-screenshots.capture.ts
@@ -105,14 +105,14 @@ test('capture current product states for the README', async ({ page }) => {
   await advancedDialog.getByRole('button', { name: 'Queue combined test' }).click();
   await expect(page.getByText('1 choice · 1 reasoning · 0 attempts')).toBeVisible({ timeout: 60_000 });
 
-  await page.getByRole('button', { name: 'Home' }).click();
+  await page.getByRole('button', { name: 'Back to home' }).click();
   await page.getByRole('tab', { name: 'Documents' }).click();
   await page.getByRole('region', { name: 'Documents library' })
     .getByRole('heading', { name: 'distributed-systems-field-guide' }).click();
   await expect(page.getByText(/^Indexed ·/)).toBeVisible();
   await screenshot(page, 'document-current.jpg');
 
-  await page.getByRole('button', { name: 'Home' }).click();
+  await page.getByRole('button', { name: 'Back to home' }).click();
   await expect(page.getByRole('heading', { name: 'Welcome to Quizzer' })).toBeVisible();
   await screenshot(page, 'home-current.jpg');
 

--- a/electron-e2e/electron-shell.spec.mjs
+++ b/electron-e2e/electron-shell.spec.mjs
@@ -48,7 +48,7 @@ test.describe('Quizzer desktop shell', () => {
     }
   });
 
-  test('loads the real custom-protocol renderer with a narrow isolated preload and navigates Home', async () => {
+  test('loads the real custom-protocol renderer with a narrow isolated preload and switches sidebar destinations', async () => {
     const page = await app.firstWindow();
     assert.equal(await app.evaluate(({ app: electronApp }) => electronApp.isPackaged), false);
     await expect(page).toHaveURL('quizzer://app/');
@@ -94,7 +94,7 @@ test.describe('Quizzer desktop shell', () => {
     const documentsTab = page.locator('.desktop-sidebar').getByRole('tab', { name: 'Documents' });
     await documentsTab.click();
     await expect(page.getByText('No documents yet')).toBeVisible();
-    await page.locator('.desktop-sidebar button').filter({ hasText: /^Home$/ }).click();
+    await expect(page.locator('.desktop-sidebar button').filter({ hasText: /^Home$/ })).toHaveCount(0);
     await expect(page.getByRole('heading', { name: 'Welcome to Quizzer' })).toBeVisible();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,7 +104,6 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     onOpenPlugins: () => { setShowPluginsModal(true); setMobileMenuOpen(false); },
     onOpenSettings: () => { setShowSettingsModal(true); setMobileMenuOpen(false); },
     onOpenGeneration: () => { setShowGenerationCenter(true); setMobileMenuOpen(false); },
-    onOpenHome: () => select(null),
     onOpenTutorial: () => { setShowOnboarding(true); setMobileMenuOpen(false); },
     profile,
     dark,
@@ -164,7 +163,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
         </header>
       )}
       <main className={`app-main ${mobile && session?.mode !== 'taking' ? 'with-mobile-header' : ''}`}>
-        {selection?.kind === 'document' ? <DocumentView documentId={selection.id} /> : selection?.kind === 'test' ? (
+        {selection?.kind === 'document' ? <DocumentView documentId={selection.id} onBack={() => select(null)} /> : selection?.kind === 'test' ? (
           <MainContent
             selectedTestId={selection.id}
             setSelectedTestId={id => setSelection({ kind: 'test', id })}
@@ -172,6 +171,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
             setSession={setSession}
             onAddTest={() => setShowAddModal(true)}
             onOpenDocument={id => select({ kind: 'document', id })}
+            onBack={() => select(null)}
           />
         ) : profile ? <HomePage profile={profile} onAddDocument={() => setShowDocumentModal(true)} onAddTest={() => setShowAddModal(true)}
           onOpenGeneration={() => setShowGenerationCenter(true)} onOpenPlugins={() => setShowPluginsModal(true)}

--- a/src/components/DocumentView.tsx
+++ b/src/components/DocumentView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Alert, Button, Card, Descriptions, Empty, Input, List, Popover, Space, Spin, Tabs, Tag, Typography } from 'antd';
 import { formatErrorMessage } from '../utils/errorFormatting';
-import { DatabaseOutlined, DownloadOutlined, InfoCircleOutlined, ReloadOutlined, RobotOutlined, SearchOutlined } from '@ant-design/icons';
+import { ArrowLeftOutlined, DatabaseOutlined, DownloadOutlined, InfoCircleOutlined, ReloadOutlined, RobotOutlined, SearchOutlined } from '@ant-design/icons';
 import { ErrorDisplay } from './ErrorDisplay';
 import { db, type StoredDocument, type StoredDocumentImage } from '../db/db';
 import { getMessageApi } from '../utils/messageProvider';
@@ -11,7 +11,7 @@ import { syncNow } from '../db/serverSync';
 import { loadStoredBlob, loadStoredImageBlob } from '../utils/objectStore';
 import TagEditor from './TagEditor';
 
-interface Props { documentId: string; }
+interface Props { documentId: string; onBack: () => void; }
 
 interface IndexStatus {
   documents: Array<{ id: string; versionHash: string; chunks: number; indexedAt: number }>;
@@ -70,7 +70,7 @@ function ExtractedImagePreview({ image }: { image: StoredDocumentImage }) {
   return <img className="document-extracted-image" src={url} alt={image.caption || image.name} />;
 }
 
-export default function DocumentView({ documentId }: Props) {
+export default function DocumentView({ documentId, onBack }: Props) {
   const [document, setDocument] = useState<StoredDocument | null>();
   const [originalUrl, setOriginalUrl] = useState('');
   const [originalText, setOriginalText] = useState('');
@@ -200,6 +200,7 @@ export default function DocumentView({ documentId }: Props) {
 
   return (
     <div className="document-view">
+      <Button type="text" icon={<ArrowLeftOutlined />} onClick={onBack}>Back to home</Button>
       <div className="document-heading">
         <Typography.Title level={2}>{document.name}</Typography.Title>
         <Popover trigger="click" title="Document details" content={<Descriptions size="small" column={1} items={details} />}>

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -16,10 +16,11 @@ interface Props {
     setSession: (s: TestSession | null) => void;
     onAddTest: () => void;
     onOpenDocument: (id: string) => void;
+    onBack: () => void;
     timeLimit?: number;
 }
 
-const MainContent: React.FC<Props> = ({ selectedTestId, setSelectedTestId, session, setSession, onAddTest, onOpenDocument }) => {
+const MainContent: React.FC<Props> = ({ selectedTestId, setSelectedTestId, session, setSession, onAddTest, onOpenDocument, onBack }) => {
     const [test, setTest] = useState<StoredTest | null>(null);
     const [draft, setDraft] = useState<StoredTestDraft | undefined>();
     const [starting, setStarting] = useState(false);
@@ -92,7 +93,7 @@ const MainContent: React.FC<Props> = ({ selectedTestId, setSelectedTestId, sessi
     const latest = test.attempts[test.attempts.length - 1];
 
     if ((!test.attempts.length || draft) && !session) {
-        return <TestStart test={test} draft={draft} onStart={handleStartTest} onResume={() => void handleResume()} onOpenDocument={onOpenDocument} />;
+        return <TestStart test={test} draft={draft} onStart={handleStartTest} onResume={() => void handleResume()} onOpenDocument={onOpenDocument} onBack={onBack} />;
     }
 
     if (session?.mode === 'taking') {
@@ -112,11 +113,12 @@ const MainContent: React.FC<Props> = ({ selectedTestId, setSelectedTestId, sessi
                 onStart={handleStartTest}
                 onResume={() => void handleResume()}
                 onOpenDocument={onOpenDocument}
+                onBack={onBack}
             />
         );
     }
 
-    return <TestSummary test={test} setSession={setSession} setStarting={setStarting} onNewTestCreated={handleNewTestCreated} />;
+    return <TestSummary test={test} setSession={setSession} setStarting={setStarting} onNewTestCreated={handleNewTestCreated} onBack={onBack} />;
 };
 
 export default MainContent;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Badge, Button, Empty, Input, Layout, List, Popconfirm, Space, Tabs, Tag, Typography } from 'antd';
-import { ApiOutlined, DeleteOutlined, FileTextOutlined, FormOutlined, HomeOutlined, PlusOutlined, QuestionCircleOutlined, SearchOutlined, SettingOutlined, SyncOutlined } from '@ant-design/icons';
+import { ApiOutlined, DeleteOutlined, FileTextOutlined, FormOutlined, PlusOutlined, QuestionCircleOutlined, SearchOutlined, SettingOutlined, SyncOutlined } from '@ant-design/icons';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db, type StoredAppProfile } from '../db/db';
 import { getMessageApi } from '../utils/messageProvider';
@@ -16,14 +16,13 @@ interface Props {
   onOpenPlugins: () => void;
   onOpenSettings: () => void;
   onOpenGeneration: () => void;
-  onOpenHome: () => void;
   onOpenTutorial: () => void;
   profile?: StoredAppProfile;
   dark: boolean;
   embedded?: boolean;
 }
 
-export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument, onOpenPlugins, onOpenSettings, onOpenGeneration, onOpenHome, onOpenTutorial, profile, dark, embedded = false }: Props) {
+export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument, onOpenPlugins, onOpenSettings, onOpenGeneration, onOpenTutorial, profile, dark, embedded = false }: Props) {
   const tests = useLiveQuery(() => db.tests.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const documents = useLiveQuery(() => db.documents.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const [tab, setTab] = useState<'tests' | 'documents'>(selection?.kind === 'document' ? 'documents' : 'tests');
@@ -56,9 +55,6 @@ export default function Sidebar({ selection, onSelect, onAddTest, onAddDocument,
   const content = (
     <div className="sidebar-content">
       <Typography.Title level={4} style={{ textAlign: 'center', margin: '22px 0 10px' }}>Quizzer</Typography.Title>
-      <div className="sidebar-home">
-        <Button block type={!selection ? 'primary' : 'text'} icon={<HomeOutlined />} onClick={onOpenHome}>Home</Button>
-      </div>
       <Tabs activeKey={tab} onChange={key => { setTab(key as typeof tab); setQuery(''); }} centered
         items={[
           { key: 'tests', label: 'Tests', icon: <FormOutlined /> },

--- a/src/components/TestStart.tsx
+++ b/src/components/TestStart.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Typography, Checkbox, InputNumber, Popconfirm, Radio, Space, Tag } from 'antd';
-import { FileTextOutlined } from '@ant-design/icons';
+import { ArrowLeftOutlined, FileTextOutlined } from '@ant-design/icons';
 import type { StoredTest, StoredTestDraft } from '../db/db';
 import { useState } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
@@ -14,9 +14,10 @@ interface Props {
     onStart: (options: { timeLimit?: number; practice: boolean }) => void;
     onResume: () => void;
     onOpenDocument: (id: string) => void;
+    onBack: () => void;
 }
 
-const TestStart: React.FC<Props> = ({ test, draft, onStart, onResume, onOpenDocument }) => {
+const TestStart: React.FC<Props> = ({ test, draft, onStart, onResume, onOpenDocument, onBack }) => {
     const [timed, setTimed] = useState(false);
     const [durationMinutes, setDurationMinutes] = useState(15); // default to 15 mins
     const [mode, setMode] = useState<'test' | 'practice'>('test');
@@ -25,6 +26,7 @@ const TestStart: React.FC<Props> = ({ test, draft, onStart, onResume, onOpenDocu
     const sourceDocuments = useLiveQuery(() => db.documents.bulkGet(documentIds), [test.id, documentIds.join('|')]);
 
     return <div className="test-start">
+      <Button className="test-back-button" type="text" icon={<ArrowLeftOutlined />} onClick={onBack}>Back to home</Button>
       <div className="test-start-main">
         <Title level={2} style={{ marginBottom: 8 }}>{test.name}</Title>
         <Paragraph type="secondary" style={{ fontSize: 16, marginBottom: 32 }}>

--- a/src/components/TestSummary.tsx
+++ b/src/components/TestSummary.tsx
@@ -19,6 +19,7 @@ import { getMessageApi } from '../utils/messageProvider';
 import { countQuestionTypes, getQuestionType, isQuestionCorrect } from '../utils/questions';
 import { buildCoveragePlan, ensureDocumentChunks, retrievalContextForSlots } from '../utils/sourcePlanning';
 import { syncNow } from '../db/serverSync';
+import { ArrowLeftOutlined } from '@ant-design/icons';
 
 const { Title, Paragraph, Text } = Typography;
 const shuffle = <T,>(items: T[]): T[] => {
@@ -35,6 +36,7 @@ interface Props {
     setSession: (s: TestSession) => void;
     onNewTestCreated: (s: string) => void;
     setStarting: (b: boolean) => void;
+    onBack: () => void;
 }
 
 const formatDate = (timestamp: number) => {
@@ -49,7 +51,7 @@ const formatTime = (timestamp: number) => {
 };
 
 
-const TestSummary: React.FC<Props> = ({ test, setSession, onNewTestCreated, setStarting }) => {
+const TestSummary: React.FC<Props> = ({ test, setSession, onNewTestCreated, setStarting, onBack }) => {
     const [rawJson, setRawJson] = useState<string | null>(null);
     const [jsonError, setJsonError] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -225,6 +227,7 @@ const TestSummary: React.FC<Props> = ({ test, setSession, onNewTestCreated, setS
                     gap: 24,
                 }}
             >
+                <Button className="test-back-button" type="text" icon={<ArrowLeftOutlined />} onClick={onBack}>Back to home</Button>
                 {/* Left: Summary Card */}
                 <div className="summary-main">
                     <Card

--- a/src/index.css
+++ b/src/index.css
@@ -40,8 +40,6 @@ button, input, textarea, select { font: inherit; }
 .desktop-sidebar { background: var(--surface) !important; border-right: 1px solid var(--border); overflow: hidden; }
 .sidebar-content { height: 100%; display: flex; flex-direction: column; background: var(--surface); }
 .sidebar-controls { padding: 0 12px 12px; flex: 0 0 auto; }
-.sidebar-home { padding: 0 12px 4px; }
-.sidebar-home .ant-btn { justify-content: flex-start; }
 .sidebar-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 0 8px; }
 .sidebar-footer { margin: 8px 12px 14px; flex: 0 0 auto; display: grid; gap: 2px; }
 .sidebar-footer .ant-btn { justify-content: flex-start; }
@@ -229,7 +227,9 @@ button, input, textarea, select { font: inherit; }
 .ai-chat-composer { position: relative; margin: 0 12px 12px; flex: 0 0 auto; }
 .ai-chat-composer textarea { min-height: 50px !important; padding: 13px 56px 13px 16px !important; border-radius: 14px !important; background: var(--surface-soft) !important; }
 .ai-chat-composer-action { position: absolute; top: 10px; right: 10px; z-index: 1; width: 30px; min-width: 30px; height: 30px; }
-.test-start { width: 100%; height: 100%; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 340px); background: var(--surface); overflow: hidden; }
+.test-start { position: relative; width: 100%; height: 100%; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 340px); background: var(--surface); overflow: hidden; }
+.test-summary { position: relative; }
+.test-back-button { position: absolute; top: 16px; left: 16px; z-index: 1; }
 .test-start-main { min-height: 0; padding: 64px 32px; display: flex; align-items: center; flex-direction: column; justify-content: center; text-align: center; overflow-y: auto; }
 .test-source-sidebar { height: 100%; min-height: 0; padding: 20px 0 32px 20px; border-left: 1px solid var(--border); background: var(--surface-soft); display: flex; flex-direction: column; overflow: hidden; text-align: left; }
 .test-source-title { margin: 0 4px 16px !important; flex: 0 0 auto; }


### PR DESCRIPTION
Closes #66

This PR is stacked on #77 because both changes simplify the sidebar.

- remove the persistent Home sidebar button
- add top-left Back to home actions on test and document screens
- update navigation and paused-practice browser coverage