### PR TITLE
Split Activity into generation and indexing tabs

### DIFF
--- a/e2e/activity.spec.ts
+++ b/e2e/activity.spec.ts
@@ -8,8 +8,11 @@ test('activity is a monitoring-only view', async ({ page }) => {
 
   const activity = page.getByRole('dialog', { name: 'Activity' });
   await expect(activity).toBeVisible();
-  await expect(activity.getByRole('heading', { name: 'Quiz generation' })).toBeVisible();
-  await expect(activity.getByRole('heading', { name: 'Document indexing' })).toBeVisible();
+  await expect(activity.getByRole('tab', { name: 'Quiz generation' })).toHaveAttribute('aria-selected', 'true');
+  await expect(activity.getByText('No generation jobs')).toBeVisible();
+  await activity.getByRole('tab', { name: 'Document indexing' }).click();
+  await expect(activity.getByRole('tab', { name: 'Document indexing' })).toHaveAttribute('aria-selected', 'true');
+  await expect(activity.getByText('No indexing jobs')).toBeVisible();
   await expect(activity.getByRole('slider')).toHaveCount(0);
   await expect(activity.getByText('Background work survives reloads and connection interruptions')).toHaveCount(0);
 });

--- a/src/components/GenerationCenter.tsx
+++ b/src/components/GenerationCenter.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Alert, Button, Checkbox, Collapse, Empty, Input, InputNumber, List, Modal, Progress, Select, Space, Tag, Typography } from 'antd';
+import { Alert, Button, Checkbox, Collapse, Empty, Input, InputNumber, List, Modal, Progress, Select, Space, Tabs, Tag, Typography } from 'antd';
 import { ErrorDisplay } from './ErrorDisplay';
 import { formatErrorMessage } from '../utils/errorFormatting';
 import { CloseOutlined, DatabaseOutlined, PlayCircleOutlined, ReloadOutlined } from '@ant-design/icons';
@@ -362,20 +362,28 @@ interface CenterProps { open: boolean; onClose: () => void; onOpenTest: (id: str
 export function GenerationCenter({ open, onClose, onOpenTest, onManagePlugins }: CenterProps) {
   const jobs = useLiveQuery(() => db.generationJobs.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const indexJobs = useLiveQuery(() => db.indexJobs.orderBy('createdAt').reverse().toArray(), []) ?? [];
-  const clearFinished = async () => Promise.all([
-    db.generationJobs.bulkDelete(jobs.filter(job => terminalStatuses.has(job.status)).map(job => job.id)),
-    db.indexJobs.bulkDelete(indexJobs.filter(job => terminalStatuses.has(job.status)).map(job => job.id)),
-  ]);
-  const hasFinished = jobs.some(job => terminalStatuses.has(job.status)) || indexJobs.some(job => terminalStatuses.has(job.status));
+  const finishedGenerationIds = jobs.filter(job => terminalStatuses.has(job.status)).map(job => job.id);
+  const finishedIndexIds = indexJobs.filter(job => terminalStatuses.has(job.status)).map(job => job.id);
   return <Modal open={open} width={780} title="Activity" footer={null} onCancel={onClose}>
-    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-      <Typography.Title level={5} style={{ margin: 0 }}>Quiz generation</Typography.Title>
-      {hasFinished && <Button size="small" onClick={() => void clearFinished()}>Clear finished</Button>}
-      <List locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No generation jobs" /> }} dataSource={jobs}
-        renderItem={job => <JobItem job={job} onOpenTest={id => { onOpenTest(id); onClose(); }} onManagePlugins={onManagePlugins} />} />
-      <Typography.Title level={5} style={{ margin: 0 }}>Document indexing</Typography.Title>
-      <List locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No indexing jobs" /> }} dataSource={indexJobs}
-        renderItem={job => <IndexJobItem job={job} />} />
-    </Space>
+    <Tabs items={[
+      {
+        key: 'generation',
+        label: 'Quiz generation',
+        children: <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          {!!finishedGenerationIds.length && <Button size="small" onClick={() => void db.generationJobs.bulkDelete(finishedGenerationIds)}>Clear finished</Button>}
+          <List locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No generation jobs" /> }} dataSource={jobs}
+            renderItem={job => <JobItem job={job} onOpenTest={id => { onOpenTest(id); onClose(); }} onManagePlugins={onManagePlugins} />} />
+        </Space>,
+      },
+      {
+        key: 'indexing',
+        label: 'Document indexing',
+        children: <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          {!!finishedIndexIds.length && <Button size="small" onClick={() => void db.indexJobs.bulkDelete(finishedIndexIds)}>Clear finished</Button>}
+          <List locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No indexing jobs" /> }} dataSource={indexJobs}
+            renderItem={job => <IndexJobItem job={job} />} />
+        </Space>,
+      },
+    ]} />
   </Modal>;
 }


### PR DESCRIPTION
Closes #63

- separate quiz generation and document indexing into dedicated tabs
- scope Clear finished to the active job type
- cover tab navigation and empty states in the Activity browser test