### PR TITLE
Let users discard failed background jobs

### DIFF
--- a/e2e/activity.spec.ts
+++ b/e2e/activity.spec.ts
@@ -16,3 +16,44 @@ test('activity is a monitoring-only view', async ({ page }) => {
   await expect(activity.getByRole('slider')).toHaveCount(0);
   await expect(activity.getByText('Background work survives reloads and connection interruptions')).toHaveCount(0);
 });
+
+test('failed generation and indexing jobs can be discarded', async ({ page }) => {
+  await dismissOnboarding(page);
+  await page.evaluate(async () => {
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('QuizDB');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    const transaction = database.transaction(['generationJobs', 'indexJobs'], 'readwrite');
+    transaction.objectStore('generationJobs').put({
+      id: 'failed-generation', testId: 'test-1', name: 'Failed quiz', createdAt: Date.now(), updatedAt: Date.now(),
+      status: 'error', documentIds: [], options: { provider: 'codex', questionCount: 1 }, questions: [], rejected: 0, rounds: {}, error: 'Provider failed',
+    });
+    transaction.objectStore('indexJobs').put({
+      id: 'failed-index', kind: 'index', status: 'failed', documentIds: ['document-1'], remainingDocumentIds: ['document-1'],
+      completedDocumentIds: [], results: [], force: false, createdAt: Date.now(), updatedAt: Date.now(), error: 'Index failed',
+    });
+    await new Promise<void>((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () => reject(transaction.error);
+    });
+    database.close();
+  });
+  await page.reload();
+  await dismissOnboarding(page, false);
+  await page.locator('.desktop-sidebar button').filter({ hasText: 'Activity' }).click();
+
+  const activity = page.getByRole('dialog', { name: 'Activity' });
+  await expect(activity.getByText('Failed quiz')).toBeVisible();
+  await activity.getByRole('button', { name: 'Discard' }).click();
+  await page.getByRole('button', { name: 'Discard' }).last().click();
+  await expect(activity.getByText('Failed quiz')).toHaveCount(0);
+
+  await activity.getByRole('tab', { name: 'Document indexing' }).click();
+  await expect(activity.getByRole('button', { name: 'Resume remaining' })).toBeVisible();
+  await activity.getByRole('button', { name: 'Discard' }).click();
+  await page.getByRole('button', { name: 'Discard' }).last().click();
+  await expect(activity.getByRole('button', { name: 'Resume remaining' })).toHaveCount(0);
+});

--- a/src/components/GenerationCenter.tsx
+++ b/src/components/GenerationCenter.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Alert, Button, Checkbox, Collapse, Empty, Input, InputNumber, List, Modal, Progress, Select, Space, Tabs, Tag, Typography } from 'antd';
+import { Alert, Button, Checkbox, Collapse, Empty, Input, InputNumber, List, Modal, Popconfirm, Progress, Select, Space, Tabs, Tag, Typography } from 'antd';
 import { ErrorDisplay } from './ErrorDisplay';
 import { formatErrorMessage } from '../utils/errorFormatting';
 import { CloseOutlined, DatabaseOutlined, PlayCircleOutlined, ReloadOutlined } from '@ant-design/icons';
@@ -297,6 +297,8 @@ function JobItem({ job, onOpenTest, onManagePlugins }: { job: StoredGenerationJo
         {(job.status === 'queued' || job.status === 'running' || job.status === 'waiting' || job.status === 'paused') &&
           <Button danger size="small" icon={<CloseOutlined />} onClick={() => void cancelGenerationJob(job.id)}>Cancel</Button>}
         {job.status === 'error' && <Button size="small" icon={<ReloadOutlined />} onClick={() => void retryGenerationJob(job.id)}>Retry from checkpoint</Button>}
+        {job.status === 'error' && <Popconfirm title="Discard this failed generation?" description="Saved progress for this job will be removed." okText="Discard" okButtonProps={{ danger: true }}
+          onConfirm={() => void removeGenerationJob(job.id)}><Button danger size="small" type="text">Discard</Button></Popconfirm>}
         {job.status === 'completed' && <Button size="small" type="primary" onClick={() => onOpenTest(job.testId)}>Open test</Button>}
         {terminalStatuses.has(job.status) && <Button size="small" type="text" onClick={() => void removeGenerationJob(job.id)}>Dismiss</Button>}
       </Space>
@@ -350,6 +352,8 @@ function IndexJobItem({ job }: { job: StoredIndexJob }) {
           onClick={() => void control('cancel')}>Cancel</Button>}
         {(job.status === 'failed' || job.status === 'cancelled') && <Button size="small" loading={working} icon={<ReloadOutlined />}
           onClick={() => void control('resume')}>Resume remaining</Button>}
+        {job.status === 'failed' && <Popconfirm title="Discard this failed indexing job?" description="Saved progress for this job will be removed." okText="Discard" okButtonProps={{ danger: true }}
+          onConfirm={() => void db.indexJobs.delete(job.id)}><Button danger size="small" type="text">Discard</Button></Popconfirm>}
         {(job.status === 'completed' || job.status === 'cancelled') && <Button size="small" type="text"
           onClick={() => void db.indexJobs.delete(job.id)}>Dismiss</Button>}
       </Space>


### PR DESCRIPTION
Closes #65

This PR is stacked on #79 because both changes update Activity.

- add confirmed Discard actions for failed generation and indexing jobs
- preserve Retry and Resume as the primary recovery paths
- cover removal of both failed job types in the Activity browser test