### PR TITLE
Detect existing Antigravity CLI sessions automatically

### DIFF
--- a/e2e/plugins-modal.spec.ts
+++ b/e2e/plugins-modal.spec.ts
@@ -40,3 +40,31 @@ test('Plugins & models exposes capability tabs without inline settings dropdowns
   const ollamaSettings = page.getByRole('dialog', { name: 'Ollama Local settings' });
   await expect(ollamaSettings.getByText('Resource limits')).toHaveCount(0);
 });
+
+test('uninstalled plugin and provider options do not show enable switches', async ({ page }) => {
+  await page.route('**/api/integrations', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      marker: { installed: false, managed: false, job: { state: 'idle', message: '' } },
+      ocr: { installed: false, managed: false, job: { state: 'idle', message: '' } },
+      codex: { installed: false, connected: false, job: { state: 'idle', message: '' } },
+      'claude-agent': { installed: false, connected: false, job: { state: 'idle', message: '' } },
+      'antigravity-agent': { installed: false, connected: false, job: { state: 'idle', message: '' } },
+      ollama: { installed: false, serverReady: false, models: [], job: { state: 'idle', message: '' } },
+      'llama-cpp': { configured: false, serverReady: false, models: [], capabilities: [] },
+      embeddings: { installed: false, runtimeInstalled: false, model: 'nomic-embed-text', job: { state: 'idle', message: '' } },
+    }),
+  }));
+  await dismissOnboarding(page);
+  await page.getByRole('button', { name: 'Configure AI' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Plugins & models' });
+  await expect(dialog.getByRole('switch', { name: 'Use Marker for automatic PDF extraction' })).toHaveCount(0);
+  await dialog.getByRole('tab', { name: 'Image OCR' }).click();
+  await expect(dialog.getByRole('switch', { name: 'Enable RapidOCR' })).toHaveCount(0);
+  await dialog.getByRole('tab', { name: 'Embeddings' }).click();
+  await expect(dialog.getByRole('switch', { name: 'Enable Ollama embeddings' })).toHaveCount(0);
+  await dialog.getByRole('tab', { name: 'Models' }).click();
+  await expect(dialog.getByRole('switch', { name: 'Enable Codex Agent' })).toHaveCount(0);
+  await expect(dialog.getByRole('switch', { name: 'Enable Ollama Local' })).toHaveCount(0);
+});

--- a/server.mjs
+++ b/server.mjs
@@ -465,12 +465,13 @@ const integrationStatus = async () => {
   const settings = await loadResolvedSettings(appDataDirectory);
   const runtime = await llamaCppRuntime.getStatus();
   const llamaEndpoint = runtime.state === 'running' ? llamaCppRuntime.endpointFor({ host: '127.0.0.1', port: runtime.port }) : settings.values['providers.llama-cpp.endpoint'];
-  const [codexInstalled, codexConnected, claudeInstalled, claudeConnected, antigravityInstalled, ollamaInstalled, ollama, llamaCpp, managedMarker, systemMarker, managedOcr] = await Promise.all([
+  const [codexInstalled, codexConnected, claudeInstalled, claudeConnected, antigravityInstalled, antigravityConnected, ollamaInstalled, ollama, llamaCpp, managedMarker, systemMarker, managedOcr] = await Promise.all([
     commandWorks('codex', ['--version']),
     commandWorks('codex', ['login', 'status']),
     commandWorks('claude', ['--version']),
     commandWorks('claude', ['auth', 'status']),
     commandWorks('agy', ['--version']),
+    commandWorks('agy', ['-p', '/model', '--output-format', 'json'], 15_000),
     commandWorks(ollamaExecutable, ['--version']),
     listOllamaModels(globalThis.fetch, AbortSignal.timeout(3_000)).catch(() => ({ serverReady: false, models: [] })),
     getLlamaCppStatus({ endpoint: llamaEndpoint }, globalThis.fetch, AbortSignal.timeout(3_500)),
@@ -485,8 +486,10 @@ const integrationStatus = async () => {
     'claude-agent': { installed: claudeInstalled, connected: claudeConnected, job: integrationJobs['claude-agent'] },
     'antigravity-agent': {
       installed: antigravityInstalled,
-      connected: integrationJobs['antigravity-agent'].state === 'complete',
-      job: integrationJobs['antigravity-agent'],
+      connected: antigravityConnected || integrationJobs['antigravity-agent'].state === 'complete',
+      job: antigravityConnected && integrationJobs['antigravity-agent'].state !== 'working'
+        ? { state: 'complete', message: 'Antigravity is connected.' }
+        : integrationJobs['antigravity-agent'],
     },
     gemini: { available: true },
     anthropic: { available: true },
@@ -599,14 +602,14 @@ const connectCodex = () => {
   });
 };
 
-const connectAgent = (provider, command, args, startingMessage) => {
+const connectAgent = (provider, command, args, startingMessage, completedMessage) => {
   if (integrationJobs[provider].state === 'working') return;
   integrationJobs[provider] = { state: 'working', message: startingMessage };
   void runCommand(command, args, {
     timeout: 15 * 60_000,
     onOutput: output => { integrationJobs[provider].message = output || integrationJobs[provider].message; },
   }).then(output => {
-    integrationJobs[provider] = { state: 'complete', message: output || `${provider} is connected.` };
+    integrationJobs[provider] = { state: 'complete', message: completedMessage || output || `${provider} is connected.` };
   }).catch(error => {
     integrationJobs[provider] = { state: 'error', message: error instanceof Error ? error.message : `${provider} login failed` };
   });
@@ -615,6 +618,7 @@ const connectAgent = (provider, command, args, startingMessage) => {
 const connectClaude = () => connectAgent('claude-agent', 'claude', ['auth', 'login'], 'Starting Claude sign-in…');
 const connectAntigravity = () => connectAgent(
   'antigravity-agent', 'agy', ['-p', '/model', '--output-format', 'json'], 'Starting Antigravity sign-in…',
+  'Antigravity is connected.',
 );
 
 const downloadAndRunScript = async (url, args, onOutput) => {

--- a/src/components/PluginsModal.tsx
+++ b/src/components/PluginsModal.tsx
@@ -119,6 +119,7 @@ interface IntegrationOptionProps {
   checked?: boolean;
   switchLabel?: string;
   switchDisabled?: boolean;
+  showSwitch?: boolean;
   onToggle?: (checked: boolean) => void;
   actions?: ReactNode;
   details?: ReactNode;
@@ -126,7 +127,7 @@ interface IntegrationOptionProps {
 }
 
 function IntegrationOption({
-  icon, title, description, state, checked, switchLabel, switchDisabled, onToggle, actions, details, warning,
+  icon, title, description, state, checked, switchLabel, switchDisabled, showSwitch = true, onToggle, actions, details, warning,
 }: IntegrationOptionProps) {
   return (
     <section className={`plugin-option${warning ? ' plugin-option-warning' : ''}`}>
@@ -139,7 +140,7 @@ function IntegrationOption({
         </div>
         <Space className="plugin-option-actions" size="small" wrap>
           {actions}
-          {onToggle ? <Switch checked={checked} disabled={switchDisabled} onChange={onToggle} aria-label={switchLabel ?? `Enable ${title}`} /> : null}
+          {onToggle && showSwitch ? <Switch checked={checked} disabled={switchDisabled} onChange={onToggle} aria-label={switchLabel ?? `Enable ${title}`} /> : null}
         </Space>
       </div>
       {details ? <div className="plugin-option-details">{details}</div> : null}
@@ -735,6 +736,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         description="Optional richer local extraction for PDFs with complex layouts and images."
         state={status?.marker?.job?.state === 'working' ? 'Installing…' : status?.marker?.installed ? 'Detected · installed' : 'Not installed'}
         checked={Boolean(status?.marker?.installed && enabledTools.marker)} switchLabel="Use Marker for automatic PDF extraction"
+        showSwitch={Boolean(status?.marker?.installed)}
         switchDisabled={!status?.marker?.installed || status?.marker?.job?.state === 'working'}
         onToggle={checked => setEnabledTools(current => ({ ...current, marker: checked }))}
         actions={!status?.marker?.installed && status?.marker?.job?.state !== 'working'
@@ -751,6 +753,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         description="Managed local OCR for labels, diagrams, and screenshots extracted from documents."
         state={status?.ocr?.job?.state === 'working' ? 'Installing…' : status?.ocr?.installed ? 'Detected · installed' : 'Not installed'}
         checked={Boolean(status?.ocr?.installed && ocrPlugin === 'builtin' && enabledTools.ocr)} switchLabel="Enable RapidOCR"
+        showSwitch={Boolean(status?.ocr?.installed)}
         switchDisabled={!status?.ocr?.installed || status?.ocr?.job?.state === 'working'}
         onToggle={checked => { if (checked) setOcrPlugin('builtin'); setEnabledTools(current => ({ ...current, ocr: checked })); }}
         actions={!status?.ocr?.installed && status?.ocr?.job?.state !== 'working'
@@ -767,6 +770,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         description="Local semantic embeddings for hybrid retrieval and duplicate filtering."
         state={status?.embeddings?.job?.state === 'working' ? 'Installing…' : status?.embeddings?.installed ? 'Detected · installed' : 'Model not installed'}
         checked={Boolean(status?.embeddings?.installed && embedderPlugin === 'builtin' && enabledTools.embeddings)} switchLabel="Enable Ollama embeddings"
+        showSwitch={Boolean(status?.embeddings?.installed)}
         switchDisabled={!status?.embeddings?.installed || status?.embeddings?.job?.state === 'working'}
         onToggle={checked => { if (checked) setEmbedderPlugin('builtin'); setEnabledTools(current => ({ ...current, embeddings: checked })); }}
         actions={!status?.embeddings?.installed && status?.embeddings?.job?.state !== 'working'
@@ -818,6 +822,7 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
             state={working ? 'Working…' : ready ? (enabledProviders[provider.id] ? 'Detected · enabled' : 'Detected · disabled')
               : provider.kind === 'api' ? 'Settings required' : provider.kind === 'agent' && agent?.installed ? 'Sign-in required' : 'Not ready'}
             checked={ready && enabledProviders[provider.id]} switchLabel={`Enable ${providerName(provider.label)}`}
+            showSwitch={ready}
             switchDisabled={!ready || working} onToggle={checked => setEnabledProviders(current => ({ ...current, [provider.id]: checked }))}
             actions={actions} details={agent?.job?.message ? <pre className="plugin-output">{agent.job.message}</pre> : undefined} />
         );


### PR DESCRIPTION
Closes #70

This PR is stacked on #81 because both fixes affect provider availability in Plugins & models.

- probe the zero-token Antigravity model command when loading integration status
- recognize an existing system login without requiring Connect
- replace raw command JSON with a concise connected status

Verified with the installed agy CLI and the full server API suite.