### PR TITLE
Package dense retrieval dependencies and sanitize warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@lancedb/lancedb": "^0.22.3",
         "@uiw/react-codemirror": "^4.23.13",
         "antd": "^5.26.2",
+        "apache-arrow": "^18.1.0",
         "better-sqlite3": "^12.11.1",
         "dexie": "^4.0.11",
         "dexie-react-hooks": "^1.1.7",
@@ -3378,7 +3379,6 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
       "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3475,15 +3475,13 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
       "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -4388,7 +4386,6 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
       "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",
@@ -4409,7 +4406,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4455,7 +4451,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4913,7 +4908,6 @@
       "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
       "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -5208,7 +5202,6 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
       "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -5224,7 +5217,6 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
       "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -5240,7 +5232,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
       "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -5250,7 +5241,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
       "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -6919,7 +6909,6 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^3.0.1"
       },
@@ -6960,8 +6949,7 @@
       "version": "24.12.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
       "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.3.3",
@@ -8004,7 +7992,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -8232,8 +8219,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -12231,7 +12217,6 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -12245,7 +12230,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
       "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -12593,8 +12577,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -12673,7 +12656,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13141,7 +13123,6 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
       "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@google/generative-ai": "^0.24.1",
     "@lancedb/lancedb": "^0.22.3",
     "@uiw/react-codemirror": "^4.23.13",
+    "apache-arrow": "^18.1.0",
     "antd": "^5.26.2",
     "better-sqlite3": "^12.11.1",
     "dexie": "^4.0.11",

--- a/src/components/DocumentView.tsx
+++ b/src/components/DocumentView.tsx
@@ -210,7 +210,7 @@ export default function DocumentView({ documentId }: Props) {
         message={indexStatus.dense.status === 'ready'
           ? `Dense retrieval ready · ${indexStatus.dense.embeddingModel}`
           : indexStatus.dense.status === 'unavailable' ? 'Dense retrieval is unavailable; sparse search remains ready' : 'Dense retrieval will be built during indexing'}
-        description={indexStatus.dense.issue?.message} />}
+        description={indexStatus.dense.status === 'unavailable' ? 'Quizzer will continue using keyword search for this document.' : undefined} />}
       <Card size="small" title="Tags" style={{ marginBottom: 20 }}>
         <Space.Compact style={{ width: '100%' }}>
           <Input value={tagText} onChange={event => setTagText(event.target.value)} placeholder="lecture, networking, exam-1" />

--- a/test/forge-security.test.mjs
+++ b/test/forge-security.test.mjs
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import { FuseVersion, FuseV1Options } from '@electron/fuses';
 import forgeConfig, { electronExecutableForBuild, electronFuseConfig } from '../forge.config.mjs';
+
+test('packages the complete built-in vector index dependency graph', async () => {
+  const packageMetadata = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+  assert.equal(packageMetadata.dependencies['apache-arrow'], '^18.1.0');
+});
 
 test('packages application code in an ASAR archive', () => {
   assert.deepEqual(forgeConfig.packagerConfig.asar, {


### PR DESCRIPTION
Closes #71

- declare Apache Arrow as a direct runtime dependency so Electron packaging retains it
- keep raw module failures out of the document UI
- retain a concise keyword-search fallback message
- add a packaging dependency regression test