### PR TITLE
Separate document tags from technical details

### DIFF
--- a/e2e/documents.spec.ts
+++ b/e2e/documents.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+import { dismissOnboarding } from './helpers';
+
+test('document tags are individual items and technical details live in a popover', async ({ page }) => {
+  await dismissOnboarding(page);
+  await page.getByRole('button', { name: 'Add documents' }).last().click();
+
+  const dialog = page.getByRole('dialog', { name: 'Add documents' });
+  await dialog.locator('input[type="file"]').setInputFiles({
+    name: 'study-guide.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('A short local study guide.'),
+  });
+  await expect(dialog.getByText('ready', { exact: true })).toBeVisible();
+  await dialog.getByRole('button', { name: 'Add tag to study-guide' }).click();
+  await dialog.getByRole('textbox', { name: 'Add tag to study-guide' }).fill('exam');
+  await dialog.getByRole('textbox', { name: 'Add tag to study-guide' }).press('Enter');
+  await expect(dialog.getByText('exam', { exact: true })).toBeVisible();
+  await dialog.getByRole('button', { name: 'Add to library' }).click();
+
+  const documentView = page.locator('.document-view');
+  await expect(documentView.getByRole('heading', { name: 'study-guide' })).toBeVisible();
+  await expect(documentView.getByText('exam', { exact: true })).toBeVisible();
+  await expect(documentView.getByText('text/plain', { exact: true })).toHaveCount(0);
+  await documentView.getByRole('button', { name: 'Document details' }).click();
+  const details = page.getByRole('tooltip');
+  await expect(details.getByText('text/plain', { exact: true })).toBeVisible();
+  await expect(details.getByText('utf8-1', { exact: true })).toBeVisible();
+  await expect(details.getByText('Not indexed', { exact: true })).toBeVisible();
+  await documentView.getByRole('button', { name: 'Document details' }).click();
+  await expect(details).toBeHidden();
+
+  await documentView.getByRole('button', { name: 'Add tag to study-guide' }).click();
+  await documentView.getByRole('textbox', { name: 'Add tag to study-guide' }).fill('review');
+  await documentView.getByRole('textbox', { name: 'Add tag to study-guide' }).press('Enter');
+  await expect(documentView.getByText('review', { exact: true })).toBeVisible();
+});

--- a/src/components/AddDocumentModal.tsx
+++ b/src/components/AddDocumentModal.tsx
@@ -10,6 +10,7 @@ import { chunkDocumentContent, STRUCTURAL_CHUNKER_VERSION } from '../utils/docum
 import { getProviderSettings } from '../utils/providerSettings';
 import { serviceFetch } from '../utils/serviceApi';
 import { ErrorDisplay } from './ErrorDisplay';
+import TagEditor from './TagEditor';
 
 interface PendingDocument {
   id: string;
@@ -28,7 +29,6 @@ interface Props {
   onCreated: (id: string) => void | Promise<void>;
 }
 
-const parseTags = (value: string) => value.split(',').map(tag => tag.trim()).filter(Boolean);
 const hashBytes = async (value: BufferSource) => {
   const digest = await crypto.subtle.digest('SHA-256', value);
   return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
@@ -162,8 +162,7 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
                   {item.status === 'extracting' ? <Space size={5}><Spin size="small" /> Extracting</Space> : item.status}
                 </Tag>
               </Space>
-              <Input placeholder="Tags, separated by commas" value={item.tags.join(', ')}
-                onChange={event => update(item.id, { tags: parseTags(event.target.value) })} />
+              <TagEditor tags={item.tags} subject={item.name || item.file.name} onChange={tags => update(item.id, { tags })} />
               {item.error && <ErrorDisplay error={item.error} context="document" />}
               {item.stage && <Typography.Text type="secondary">{item.stage}</Typography.Text>}
             </Space>

--- a/src/components/DocumentView.tsx
+++ b/src/components/DocumentView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Alert, Button, Card, Empty, Input, List, Space, Spin, Tabs, Tag, Typography } from 'antd';
+import { Alert, Button, Card, Descriptions, Empty, Input, List, Popover, Space, Spin, Tabs, Tag, Typography } from 'antd';
 import { formatErrorMessage } from '../utils/errorFormatting';
-import { DatabaseOutlined, DownloadOutlined, ReloadOutlined, RobotOutlined, SearchOutlined } from '@ant-design/icons';
+import { DatabaseOutlined, DownloadOutlined, InfoCircleOutlined, ReloadOutlined, RobotOutlined, SearchOutlined } from '@ant-design/icons';
 import { ErrorDisplay } from './ErrorDisplay';
 import { db, type StoredDocument, type StoredDocumentImage } from '../db/db';
 import { getMessageApi } from '../utils/messageProvider';
@@ -9,6 +9,7 @@ import DocumentAskModal from './DocumentAskModal';
 import { serviceJson, serviceRequest } from '../utils/serviceApi';
 import { syncNow } from '../db/serverSync';
 import { loadStoredBlob, loadStoredImageBlob } from '../utils/objectStore';
+import TagEditor from './TagEditor';
 
 interface Props { documentId: string; }
 
@@ -71,7 +72,6 @@ function ExtractedImagePreview({ image }: { image: StoredDocumentImage }) {
 
 export default function DocumentView({ documentId }: Props) {
   const [document, setDocument] = useState<StoredDocument | null>();
-  const [tagText, setTagText] = useState('');
   const [originalUrl, setOriginalUrl] = useState('');
   const [originalText, setOriginalText] = useState('');
   const [originalLoading, setOriginalLoading] = useState(false);
@@ -90,7 +90,6 @@ export default function DocumentView({ documentId }: Props) {
     setDocument(undefined);
     void db.documents.get(documentId).then(item => {
       setDocument(item ?? null);
-      setTagText(item?.tags.join(', ') ?? '');
     });
   }, [documentId]);
 
@@ -124,11 +123,16 @@ export default function DocumentView({ documentId }: Props) {
   if (document === undefined) return <Spin style={{ margin: 40 }} />;
   if (document === null) return <Typography.Title level={4}>Document not found</Typography.Title>;
 
-  const saveTags = async () => {
-    const tags = [...new Set(tagText.split(',').map(tag => tag.trim()).filter(Boolean))];
-    await db.documents.update(document.id, { tags });
+  const saveTags = async (tags: string[]) => {
+    const previous = document.tags;
     setDocument({ ...document, tags });
-    message.success('Tags saved');
+    try {
+      await db.documents.update(document.id, { tags });
+      message.success('Tags updated');
+    } catch (error) {
+      setDocument({ ...document, tags: previous });
+      message.error(formatErrorMessage(error, 'storage'));
+    }
   };
 
   const indexDocument = async () => {
@@ -184,39 +188,36 @@ export default function DocumentView({ documentId }: Props) {
   };
 
   const indexed = indexStatus?.documents.find(item => item.id === document.id);
+  const details = [
+    { key: 'type', label: 'Type', children: document.mimeType || 'document' },
+    ...(document.pageCount ? [{ key: 'pages', label: 'Pages', children: document.pageCount }] : []),
+    ...(document.parserVersion ? [{ key: 'extractor', label: 'Extractor', children: document.parserVersion }] : []),
+    { key: 'index', label: 'Index', children: indexed ? `${indexed.chunks} spans` : 'Not indexed' },
+    ...(document.images?.length ? [{ key: 'images', label: 'Images', children: document.images.length }] : []),
+    ...(document.extractedAt ? [{ key: 'extracted', label: 'Extracted', children: new Date(document.extractedAt).toLocaleString() }] : []),
+    ...(document.extractionHistory?.length ? [{ key: 'history', label: 'Prior extractions', children: document.extractionHistory.length }] : []),
+  ];
 
   return (
     <div className="document-view">
-      <Typography.Title level={2}>{document.name}</Typography.Title>
-      <Space wrap style={{ marginBottom: 16 }}>
-        <Tag>{document.mimeType || 'document'}</Tag>
-        {document.pageCount && <Tag>{document.pageCount} pages</Tag>}
-        {document.tags.map(tag => <Tag color="blue" key={tag}>{tag}</Tag>)}
-        {!!document.images?.length && <Tag color="purple">{document.images.length} extracted images</Tag>}
-        {document.parserVersion && <Tag color="cyan">Extractor · {document.parserVersion}</Tag>}
-        {indexed ? <Tag color="green">Indexed · {indexed.chunks} spans</Tag> : <Tag>Not indexed</Tag>}
-      </Space>
+      <div className="document-heading">
+        <Typography.Title level={2}>{document.name}</Typography.Title>
+        <Popover trigger="click" title="Document details" content={<Descriptions size="small" column={1} items={details} />}>
+          <Button type="text" shape="circle" icon={<InfoCircleOutlined />} aria-label="Document details" />
+        </Popover>
+      </div>
+      <TagEditor tags={document.tags} subject={document.name} onChange={tags => void saveTags(tags)} />
       <Space wrap style={{ marginBottom: 20 }}>
         <Button type="primary" icon={<RobotOutlined />} onClick={() => setAskOpen(true)}>Ask AI about this document</Button>
         <Button icon={indexed ? <ReloadOutlined /> : <DatabaseOutlined />} loading={indexing} onClick={() => void indexDocument()}>{indexed ? 'Reindex document' : 'Index for retrieval'}</Button>
         <Button icon={<ReloadOutlined />} loading={reextracting} disabled={!document.originalFile} onClick={() => void reextract()}>Re-extract original</Button>
       </Space>
-      {document.extractedAt && <Typography.Paragraph type="secondary">
-        Extracted {new Date(document.extractedAt).toLocaleString()} · schema v{document.extractionSchemaVersion ?? 0}
-        {document.extractionHistory?.length ? ` · ${document.extractionHistory.length} prior extraction${document.extractionHistory.length === 1 ? '' : 's'} retained` : ''}
-      </Typography.Paragraph>}
       {indexStatus?.dense?.enabled && <Alert style={{ marginBottom: 16 }} showIcon
         type={indexStatus.dense.status === 'unavailable' ? 'warning' : 'info'}
         message={indexStatus.dense.status === 'ready'
           ? `Dense retrieval ready · ${indexStatus.dense.embeddingModel}`
           : indexStatus.dense.status === 'unavailable' ? 'Dense retrieval is unavailable; sparse search remains ready' : 'Dense retrieval will be built during indexing'}
         description={indexStatus.dense.status === 'unavailable' ? 'Quizzer will continue using keyword search for this document.' : undefined} />}
-      <Card size="small" title="Tags" style={{ marginBottom: 20 }}>
-        <Space.Compact style={{ width: '100%' }}>
-          <Input value={tagText} onChange={event => setTagText(event.target.value)} placeholder="lecture, networking, exam-1" />
-          <Button type="primary" onClick={saveTags}>Save</Button>
-        </Space.Compact>
-      </Card>
       <Tabs defaultActiveKey="extracted" items={[
         { key: 'extracted', label: 'Extracted content', children: <Card>
           <Typography.Paragraph style={{ whiteSpace: 'pre-wrap', fontFamily: 'ui-monospace, monospace' }}>{document.content}</Typography.Paragraph>

--- a/src/components/TagEditor.tsx
+++ b/src/components/TagEditor.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { Button, Input, Space, Tag, Typography } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+
+interface Props {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  subject: string;
+}
+
+export default function TagEditor({ tags, onChange, subject }: Props) {
+  const [adding, setAdding] = useState(false);
+  const [value, setValue] = useState('');
+  const addLabel = `Add tag to ${subject}`;
+
+  const commit = () => {
+    const next = value.trim();
+    if (next && !tags.includes(next)) onChange([...tags, next]);
+    setValue('');
+    setAdding(false);
+  };
+
+  return <div className="document-tag-editor">
+    <Typography.Text type="secondary">Tags</Typography.Text>
+    <Space size={[6, 6]} wrap>
+      {tags.map(tag => <Tag key={tag} closable onClose={event => {
+        event.preventDefault();
+        onChange(tags.filter(item => item !== tag));
+      }}>{tag}</Tag>)}
+      {adding ? <Input autoFocus size="small" value={value} aria-label={addLabel} placeholder="Tag name"
+        onChange={event => setValue(event.target.value)} onBlur={commit} onKeyDown={event => {
+          if (event.key === 'Enter') { event.preventDefault(); event.currentTarget.blur(); }
+          if (event.key === 'Escape') { setValue(''); setAdding(false); }
+        }} />
+        : <Button size="small" type="dashed" icon={<PlusOutlined />} aria-label={addLabel} onClick={() => setAdding(true)}>Add tag</Button>}
+    </Space>
+  </div>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -170,6 +170,10 @@ button, input, textarea, select { font: inherit; }
 }
 
 .document-view { padding: 32px; max-width: 1100px; margin: 0 auto; }
+.document-heading { display: flex; align-items: center; gap: 6px; margin-bottom: 12px; }
+.document-heading h2 { margin: 0; }
+.document-tag-editor { display: grid; gap: 8px; margin-bottom: 20px; }
+.document-tag-editor .ant-input { width: 150px; }
 .document-original-frame { width: 100%; height: min(72vh, 900px); min-height: 520px; border: 0; border-radius: 6px; background: #fff; }
 .document-original-image { display: block; max-width: 100%; max-height: 72vh; margin: 0 auto; object-fit: contain; }
 .document-image-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 16px; }


### PR DESCRIPTION
Closes #74

This PR is stacked on #83 because both changes update the document details screen.

- render tags as individual removable chips with an Add tag button
- reuse the same tag editor while importing and after saving
- move MIME type, page count, extractor, index, images, and extraction history into an info popover
- cover import, tag editing, and the details popover end to end