### PR TITLE
fix: open Home on startup and resume learning only on request (#87)

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -3,23 +3,9 @@ import { expect, type Page } from '@playwright/test';
 export async function dismissOnboarding(page: Page, navigate = true) {
   if (navigate) await page.goto('/');
   await page.locator('.app-shell').waitFor();
-  const welcome = page.getByRole('heading', { name: 'Welcome to Quizzer' });
-  const pause = page.getByRole('button', { name: 'Pause' });
+  // Saved sessions must not take over startup, even when setup is unfinished.
+  await expect(page.getByRole('heading', { name: 'Welcome to Quizzer' })).toBeVisible();
   const onboarding = page.locator('.onboarding-drawer');
-  await expect.poll(async () => await welcome.isVisible() || await pause.isVisible()).toBe(true);
-  if (await pause.isVisible()) {
-    // Restarting setup while a practice session is paused can restore both
-    // surfaces after reload. Dismiss the drawer before operating the session
-    // underneath it so its mask cannot intercept the click.
-    if (await onboarding.isVisible()) {
-      await onboarding.getByRole('button', { name: 'Close' }).click();
-      await expect(onboarding).toBeHidden();
-    }
-    await pause.click();
-    await page.getByRole('button', { name: 'Back to home' }).click();
-  }
-  await expect(welcome).toBeVisible();
-
   if (await onboarding.isVisible()) {
     await onboarding.getByRole('button', { name: 'Close' }).click();
     await expect(onboarding).toBeHidden();

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -223,7 +223,6 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await page.getByRole('button', { name: 'Resume setup' }).click();
   await expect(page.getByRole('heading', { name: 'Try one question' })).toBeVisible();
   await expect(page.getByText('First question answered')).toBeVisible();
-  await page.getByRole('button', { name: 'Continue' })).toBeEnabled();
   await page.getByRole('button', { name: 'Continue' }).click();
   await expect(page.getByRole('heading', { name: 'You’re ready' })).toBeVisible();
   await page.getByRole('button', { name: 'Finish' }).click();

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -223,6 +223,7 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await page.getByRole('button', { name: 'Resume setup' }).click();
   await expect(page.getByRole('heading', { name: 'Try one question' })).toBeVisible();
   await expect(page.getByText('First question answered')).toBeVisible();
+  await page.getByRole('button', { name: 'Continue' })).toBeEnabled();
   await page.getByRole('button', { name: 'Continue' }).click();
   await expect(page.getByRole('heading', { name: 'You’re ready' })).toBeVisible();
   await page.getByRole('button', { name: 'Finish' }).click();
@@ -242,7 +243,7 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   // Merely opening the app must not unpause the timer or rewrite saved work.
   expect(await readSavedDrafts(page)).toEqual(savedDrafts);
   const resumeLearning = page.locator('.ant-card').filter({ has: page.getByText('Resume learning', { exact: true }) });
-  await resumeLearning.getByRole('button', { name: 'coordination quiz', exact: true }).click();
+  await resumeLearning.getByRole('button', { name: /coordination quiz/ }).click();
   await expect(page.getByText('Paused practice available')).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Question 1' })).toHaveCount(0);
   expect(await readSavedDrafts(page)).toEqual(savedDrafts);

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,4 +1,23 @@
-import { expect, test, type Route } from '@playwright/test';
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+async function readSavedDrafts(page: Page) {
+  return page.evaluate(async () => {
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('QuizDB');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    try {
+      return await new Promise<Array<{ testId: string; pausedAt?: number }>>((resolve, reject) => {
+        const request = database.transaction('testDrafts', 'readonly').objectStore('testDrafts').getAll();
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+    } finally {
+      database.close();
+    }
+  });
+}
 
 const candidateQuestions = (type: string, count: number) => Array.from({ length: count }, (_, index) => {
   const number = index + 1;
@@ -211,9 +230,25 @@ test('resumes real onboarding and finishes through durable quiz practice', async
   await expect(page.getByRole('heading', { name: 'Welcome to Quizzer' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Resume setup' })).toHaveCount(0);
 
+  const savedDrafts = await readSavedDrafts(page);
+  expect(savedDrafts).toHaveLength(1);
+  expect(savedDrafts[0].pausedAt).toBeGreaterThan(0);
+
   await page.reload();
-  await expect(page.getByRole('heading', { name: 'Question 1' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Welcome to Quizzer' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Question 1' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Pause', exact: true })).toHaveCount(0);
   await expect(page.getByRole('heading', { name: 'Learn from your own material' })).toHaveCount(0);
+  // Merely opening the app must not unpause the timer or rewrite saved work.
+  expect(await readSavedDrafts(page)).toEqual(savedDrafts);
+  const resumeLearning = page.locator('.ant-card').filter({ has: page.getByText('Resume learning', { exact: true }) });
+  await resumeLearning.getByRole('button', { name: 'coordination quiz', exact: true }).click();
+  await expect(page.getByText('Paused practice available')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Question 1' })).toHaveCount(0);
+  expect(await readSavedDrafts(page)).toEqual(savedDrafts);
+  await page.getByRole('button', { name: 'Resume Practice', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Question 1' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Ask AI about this answer/ })).toBeVisible();
   await page.getByRole('button', { name: 'Pause' }).click();
   await page.getByRole('button', { name: 'Back to home' }).click();
   await expect(page.getByRole('heading', { name: 'Welcome to Quizzer' })).toBeVisible();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,8 @@ import {
 interface ShellProps { dark: boolean; onThemeChange: (dark: boolean) => void; }
 
 function AppShell({ dark, onThemeChange }: ShellProps) {
+  // Opening Quizzer must not resume or mutate a saved session. Home provides
+  // the entry point; TestStart resumes only after the user chooses to do so.
   const [selection, setSelection] = useState<LibrarySelection>(null);
   const [showAddModal, setShowAddModal] = useState(false);
   const [showDocumentModal, setShowDocumentModal] = useState(false);
@@ -54,27 +56,6 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
   useRuntimeSettings(profile);
   setMessageApi(messageApi);
   setModalApi(modalApi);
-
-  useEffect(() => {
-    let active = true;
-    void db.testDrafts.orderBy('updatedAt').last().then(async draft => {
-      if (!draft || !active || !await db.tests.get(draft.testId)) return;
-      const pauseDuration = draft.pausedAt ? Math.max(0, Date.now() - draft.pausedAt) : 0;
-      const resumedStartedAt = draft.startedAt + pauseDuration;
-      if (draft.pausedAt) {
-        await db.testDrafts.put({ ...draft, pausedAt: undefined, startedAt: resumedStartedAt, updatedAt: Date.now() });
-      }
-      setSelection({ kind: 'test', id: draft.testId });
-      setSession({
-        testId: draft.testId,
-        mode: 'taking',
-        timeLimit: draft.timeLimit,
-        startedAt: resumedStartedAt,
-        options: { instantFeedback: draft.practice },
-      });
-    });
-    return () => { active = false; };
-  }, []);
 
   const select = useCallback((next: LibrarySelection) => {
     setSelection(next);
@@ -101,7 +82,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     onSelect: select,
     onAddTest: () => { setShowAddModal(true); setMobileMenuOpen(false); },
     onAddDocument: () => { setShowDocumentModal(true); setMobileMenuOpen(false); },
-    onOpenPlugins: () => { setShowPluginsModal(true); setMobileMenuOpen(false); },
+    onOpenPlugins: () => { setShowPluginsModal(true); setMobileMenuOpenOpen(false); },
     onOpenSettings: () => { setShowSettingsModal(true); setMobileMenuOpen(false); },
     onOpenGeneration: () => { setShowGenerationCenter(true); setMobileMenuOpen(false); },
     onOpenTutorial: () => { setShowOnboarding(true); setMobileMenuOpen(false); },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
     onSelect: select,
     onAddTest: () => { setShowAddModal(true); setMobileMenuOpen(false); },
     onAddDocument: () => { setShowDocumentModal(true); setMobileMenuOpen(false); },
-    onOpenPlugins: () => { setShowPluginsModal(true); setMobileMenuOpenOpen(false); },
+    onOpenPlugins: () => { setShowPluginsModal(true); setMobileMenuOpen(false); },
     onOpenSettings: () => { setShowSettingsModal(true); setMobileMenuOpen(false); },
     onOpenGeneration: () => { setShowGenerationCenter(true); setMobileMenuOpen(false); },
     onOpenTutorial: () => { setShowOnboarding(true); setMobileMenuOpen(false); },


### PR DESCRIPTION
## Summary
Fixes #87.

- Remove the startup effect that automatically selected and resumed the newest saved session.
- Leave saved answers, feedback, review marks and pause/timer metadata untouched until the user explicitly resumes through Home > Resume learning > Resume Practice/Test.
- Update the existing durable onboarding/practice end-to-end test to assert Home-first reload, unchanged saved drafts before explicit resume, and retained feedback after resuming.
- Remove the old automatic-resume workaround from the shared end-to-end setup helper so it no longer masks this regression.

## Validation
- Passed local TypeScript transpilation/syntax checks for the changed application and onboarding test files.
- Compared the application change against the exact original Git blob; only startup restoration was removed and its intent documented.
- Full dependency installation, lint, build and Playwright execution were not available in the editing sandbox because outbound Git/npm access is unavailable. The repository CI should validate these on this PR; local syntax checks are not a substitute for that suite.

## Scope and compatibility
No Plugins & Models behavior changes, data migrations, or new dependencies. Saved sessions remain recoverable; this changes when they are resumed, not what is stored.