### PR TITLE
feat: let users choose a persistent application accent color (#93)

### DIFF
--- a/e2e/accent-color.spec.ts
+++ b/e2e/accent-color.spec.ts
@@ -23,7 +23,7 @@ test('applies accents immediately in both themes and preserves the choice after 
   await chooseAccent(page, 'Purple');
   await expect(page.locator('html')).toHaveAttribute('data-accent', 'purple');
   await expect.poll(() => primaryColor(page)).toBe('#531dab');
-  await expect(page.locator('.home-page').getByRole('button', { name: 'Add documents', exact: true })).toHaveCSS('background-color', 'rgb(83, 29, 171)');
+  await expect(page.locator('.home-page button[data-onboarding-target="document"]')).toHaveCSS('background-color', 'rgb(83, 29, 171)');
   await expect(dialog.getByRole('tab', { name: 'Overall', exact: true })).toHaveCSS('background-color', 'rgb(249, 240, 255)');
   // Appearance changes neither require nor enable the server settings save.
   await expect(dialog.getByRole('button', { name: 'Save changes' })).toBeDisabled();

--- a/e2e/accent-color.spec.ts
+++ b/e2e/accent-color.spec.ts
@@ -9,7 +9,7 @@ async function openSettings(page: Page) {
 }
 
 async function chooseAccent(page: Page, name: string) {
-  const row = page.getByRole('dialog', { name: 'Settings', exact: true }).locator('#setting-accent-color');
+  const row = page.getByRole('dialog', { name: 'Settings' }).locator('#setting-accent-color');
   const select = row.getByRole('combobox', { name: 'Accent color', exact: true });
   // Ant Design renders the selected label over the read-only combobox input.
   // Click its visible selector so normal pointer actionability checks still apply.

--- a/e2e/accent-color.spec.ts
+++ b/e2e/accent-color.spec.ts
@@ -9,8 +9,14 @@ async function openSettings(page: Page) {
 }
 
 async function chooseAccent(page: Page, name: string) {
-  await page.getByRole('combobox', { name: 'Accent color' }).click();
+  const row = page.getByRole('dialog', { name: 'Settings', exact: true }).locator('#setting-accent-color');
+  const select = row.getByRole('combobox', { name: 'Accent color', exact: true });
+  // Ant Design renders the selected label over the read-only combobox input.
+  // Click its visible selector so normal pointer actionability checks still apply.
+  await row.locator('.ant-select-selector').click();
+  await expect(select).toHaveAttribute('aria-expanded', 'true');
   await page.locator('.ant-select-dropdown:visible').getByText(name, { exact: true }).click();
+  await expect(select).toHaveAttribute('aria-expanded', 'false');
 }
 
 const primaryColor = (page: Page) => page.evaluate(() => document.documentElement.style.getPropertyValue('--accent'));

--- a/e2e/accent-color.spec.ts
+++ b/e2e/accent-color.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from '@playwright/test';
+import { dismissOnboarding } from './helpers';
+
+async function openSettings(page: Page) {
+  await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Settings' });
+  await expect(dialog.getByRole('combobox', { name: 'Accent color' })).toBeVisible();
+  return dialog;
+}
+
+async function chooseAccent(page: Page, name: string) {
+  await page.getByRole('combobox', { name: 'Accent color' }).click();
+  await page.locator('.ant-select-dropdown:visible').getByText(name, { exact: true }).click();
+}
+
+const primaryColor = (page: Page) => page.evaluate(() => document.documentElement.style.getPropertyValue('--accent'));
+
+test('applies accents immediately in both themes and preserves the choice after reload', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'light' });
+  await dismissOnboarding(page);
+  const dialog = await openSettings(page);
+  await expect(page.locator('html')).toHaveAttribute('data-accent', 'blue');
+  await chooseAccent(page, 'Purple');
+  await expect(page.locator('html')).toHaveAttribute('data-accent', 'purple');
+  await expect.poll(() => primaryColor(page)).toBe('#531dab');
+  await expect(page.locator('.home-page').getByRole('button', { name: 'Add documents', exact: true })).toHaveCSS('background-color', 'rgb(83, 29, 171)');
+  await expect(dialog.getByRole('tab', { name: 'Overall', exact: true })).toHaveCSS('background-color', 'rgb(249, 240, 255)');
+  // Appearance changes neither require nor enable the server settings save.
+  await expect(dialog.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+  await dialog.locator('#setting-theme').getByText('Dark', { exact: true }).click();
+  await expect.poll(() => primaryColor(page)).toBe('#b37feb');
+  await expect(dialog.getByRole('tab', { name: 'Overall', exact: true })).toHaveCSS('background-color', 'rgb(48, 32, 68)');
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+  await page.reload();
+  await dismissOnboarding(page, false);
+  await expect(page.locator('html')).toHaveAttribute('data-accent', 'purple');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  await expect.poll(() => primaryColor(page)).toBe('#b37feb');
+
+  await openSettings(page);
+  await page.getByRole('button', { name: 'Reset accent color' }).click();
+  await expect(page.locator('html')).toHaveAttribute('data-accent', 'blue');
+  await expect.poll(() => primaryColor(page)).toBe('#69b1ff');
+  await expect(page.getByRole('button', { name: 'Reset accent color' })).toBeDisabled();
+});
+
+test('finds the accent setting by name and supports keyboard selection', async ({ page }) => {
+  await dismissOnboarding(page);
+  const dialog = await openSettings(page);
+  await dialog.getByRole('tab', { name: 'Generation', exact: true }).click();
+  await dialog.getByRole('textbox', { name: 'Search settings' }).fill('accent');
+  await dialog.getByRole('button', { name: /^Accent color/ }).click();
+  await expect(dialog.locator('#setting-accent-color')).toBeFocused();
+  const select = dialog.getByRole('combobox', { name: 'Accent color' });
+  await select.focus();
+  await select.press('ArrowDown');
+  await select.press('ArrowDown');
+  await select.press('Enter');
+  await expect(page.locator('html')).not.toHaveAttribute('data-accent', 'blue');
+  await expect(dialog.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+});
+
+test('synchronizes accent choices between open windows', async ({ context, page }) => {
+  await dismissOnboarding(page);
+  const other = await context.newPage();
+  try {
+    await dismissOnboarding(other);
+    await openSettings(page);
+    await chooseAccent(page, 'Teal');
+    await expect(other.locator('html')).toHaveAttribute('data-accent', 'teal');
+    await openSettings(other);
+    await other.getByRole('button', { name: 'Reset accent color' }).click();
+    await expect(page.locator('html')).toHaveAttribute('data-accent', 'blue');
+  } finally {
+    await other.close();
+  }
+});
+
+test('falls back from corrupt storage and reports save failures without applying an unsaved color', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('quizzer.accent-color', 'not-a-color');
+    const setItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = function (key: string, value: string) {
+      if (key === 'quizzer.accent-color') throw new DOMException('Storage is full', 'QuotaExceededError');
+      return setItem.call(this, key, value);
+    };
+  });
+  await dismissOnboarding(page);
+  await openSettings(page);
+  await expect(page.locator('html')).toHaveAttribute('data-accent', 'blue');
+  await chooseAccent(page, 'Orange');
+  await expect(page.getByText('Could not save the accent color. Check that local storage is available and try again.')).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('data-accent', 'blue');
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,9 @@ import OnboardingGuide from './components/OnboardingGuide';
 import { recordOnboardingDocument, recordOnboardingGeneration, restartOnboarding, setInterfaceMode } from './utils/appProfile';
 import { useRuntimeSettings } from './utils/useRuntimeSettings';
 import UpdateAvailableNotifier from './components/UpdateAvailableNotifier';
+import { getAccentPalette } from './utils/accentColor';
+import { useAccentColor } from './utils/useAccentColor';
+import './accent.css';
 import {
   SHORTCUT_ACTIONS,
   changeKeyboardShortcut,
@@ -205,6 +208,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
 }
 
 export default function App() {
+  const accent = useAccentColor();
   const [dark, setDark] = useState(() => {
     const saved = localStorage.getItem('quizzer.theme');
     return saved ? saved === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -216,13 +220,22 @@ export default function App() {
     localStorage.setItem('quizzer.theme', dark ? 'dark' : 'light');
   }, [dark]);
 
+  const { primary, selected, onPrimary } = getAccentPalette(accent, dark);
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.accent = accent;
+    root.style.setProperty('--accent', primary);
+    root.style.setProperty('--selected', selected);
+    root.style.setProperty('--on-accent', onPrimary);
+  }, [accent, primary, selected, onPrimary]);
+
   return (
     <ConfigProvider theme={{
       algorithm: dark ? theme.darkAlgorithm : theme.defaultAlgorithm,
       token: dark ? {
-        colorPrimary: '#69b1ff', colorLink: '#69b1ff', colorTextLightSolid: '#101214', colorTextSecondary: '#b7c0cd', colorTextDescription: '#b7c0cd', borderRadius: 8,
+        colorPrimary: primary, colorLink: primary, colorTextLightSolid: onPrimary, colorTextSecondary: '#b7c0cd', colorTextDescription: '#b7c0cd', borderRadius: 8,
       } : {
-        colorPrimary: '#0050b3', colorLink: '#0050b3', colorTextSecondary: '#595959', colorTextDescription: '#595959', colorTextDisabled: '#666666', borderRadius: 8,
+        colorPrimary: primary, colorLink: primary, colorTextSecondary: '#595959', colorTextDescription: '#595959', colorTextDisabled: '#666666', borderRadius: 8,
       },
     }}>
       <AntdApp>

--- a/src/accent.css
+++ b/src/accent.css
@@ -1,0 +1,51 @@
+/* Application accents override legacy blue decorations, not semantic status colors. */
+:root[data-accent][data-theme] .settings-row.is-changed {
+  border-color: var(--accent);
+  box-shadow: inset 3px 0 var(--accent);
+}
+:root[data-accent][data-theme] .settings-row:focus {
+  border-color: var(--accent);
+  outline-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+:root[data-accent][data-theme] .plugin-option-icon,
+:root[data-accent][data-theme] .command-palette-icon,
+:root[data-accent][data-theme] .onboarding-hero-icon,
+:root[data-accent][data-theme] .onboarding-choice-grid .ant-radio-button-wrapper-checked strong,
+:root[data-accent][data-theme] .ai-chat-scope > .anticon,
+:root[data-accent][data-theme] .ai-chat-avatar,
+:root[data-accent][data-theme] .ai-inline-citation {
+  color: var(--accent);
+}
+:root[data-accent][data-theme] .prompt-profile-choice:hover,
+:root[data-accent][data-theme] .prompt-profile-choice:focus-visible,
+:root[data-accent][data-theme] .prompt-profile-choice.is-selected {
+  border-color: var(--accent);
+}
+:root[data-accent][data-theme] .onboarding-choice-grid .ant-radio-button-wrapper-checked {
+  border-color: var(--accent) !important;
+  box-shadow: inset 0 0 0 2px var(--accent) !important;
+}
+:root[data-accent][data-theme] .onboarding-coach-highlight {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 18%, transparent), 0 4px 14px rgb(0 0 0 / 18%);
+}
+:root[data-accent][data-theme] .ai-chat-message-user .ai-chat-avatar,
+:root[data-accent][data-theme] .ai-chat-bubble {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+:root[data-accent][data-theme] .ai-thinking-dots i {
+  background: var(--accent);
+}
+:root[data-accent][data-theme] .test-source-item:not(.is-unavailable):hover,
+:root[data-accent][data-theme] .test-source-item:not(.is-unavailable):focus-visible,
+:root[data-accent][data-theme] .settings-sidebar-item:focus-visible {
+  outline-color: var(--accent);
+}
+:root[data-accent][data-theme] .ai-chat-avatar-thinking {
+  animation-name: accent-avatar-pulse;
+}
+@keyframes accent-avatar-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 transparent; }
+  50% { box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent) 14%, transparent); }
+}

--- a/src/components/AccentColorSetting.tsx
+++ b/src/components/AccentColorSetting.tsx
@@ -1,0 +1,30 @@
+import { Button, Select, Space, Tag, Typography } from 'antd';
+import { UndoOutlined } from '@ant-design/icons';
+import { ACCENT_COLORS, DEFAULT_ACCENT_COLOR, type AccentColor } from '../utils/accentColor';
+import { changeAccentColor, useAccentColor } from '../utils/useAccentColor';
+import { getMessageApi } from '../utils/messageProvider';
+
+export default function AccentColorSetting() {
+  const accent = useAccentColor();
+  const apply = (color: AccentColor) => {
+    try {
+      changeAccentColor(color);
+    } catch {
+      getMessageApi().error('Could not save the accent color. Check that local storage is available and try again.');
+    }
+  };
+
+  return <div className="settings-row" id="setting-accent-color" tabIndex={-1}>
+    <div className="settings-copy">
+      <Typography.Text strong>Accent color</Typography.Text>
+      <Typography.Text type="secondary">Choose the color of buttons, links, and highlights. Applies immediately and is saved on this device.</Typography.Text>
+      <Space size={[4, 4]} wrap><Tag>App preference</Tag></Space>
+    </div>
+    <div className="settings-control">
+      <Select<AccentColor> aria-label="Accent color" value={accent} onChange={apply}
+        options={ACCENT_COLORS.map(color => ({ value: color.id, label: color.label }))} />
+      <Button type="text" size="small" icon={<UndoOutlined />} disabled={accent === DEFAULT_ACCENT_COLOR}
+        aria-label="Reset accent color" onClick={() => apply(DEFAULT_ACCENT_COLOR)}>Reset</Button>
+    </div>
+  </div>;
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -21,6 +21,8 @@ import {
 } from '../utils/keyboardShortcuts';
 import UpdaterStatusView from './UpdaterStatus';
 import PromptStudio from './PromptStudio';
+import AccentColorSetting from './AccentColorSetting';
+import { ACCENT_COLORS } from '../utils/accentColor';
 
 type SettingValue = string | number | boolean;
 type SettingsValues = Record<string, SettingValue>;
@@ -76,6 +78,7 @@ const settingsTabs: { key: SettingsTab; label: string; description: string }[] =
 ];
 
 const overallExtraSearchTerms = ['theme', 'appearance', 'light', 'dark'];
+const accentSearchTerms = ['accent color', 'appearance', 'buttons', 'links', 'highlights', ...ACCENT_COLORS.map(color => color.label.toLowerCase())];
 const updatesExtraSearchTerms = ['software update', 'update', 'version', 'stable', 'beta'];
 const tabForDefinition = (definition: SettingDefinition): SettingsTab => {
   const section = definition.key.split('.')[0];
@@ -314,6 +317,9 @@ export default function SettingsModal({
       if (tab.key === 'overall' && searchMatches(normalizedQuery, ['Theme', 'Choose the application color theme', ...overallExtraSearchTerms])) {
         results.push({ key: 'theme', label: 'Theme', description: 'Overall appearance · Choose the application color theme.', tab: 'overall', targetId: 'setting-theme' });
       }
+      if (tab.key === 'overall' && searchMatches(normalizedQuery, accentSearchTerms)) {
+        results.push({ key: 'accent-color', label: 'Accent color', description: 'Overall appearance - Color of buttons, links, and highlights.', tab: 'overall', targetId: 'setting-accent-color' });
+      }
       if (tab.key === 'updates' && searchMatches(normalizedQuery, [tab.label, tab.description, ...updatesExtraSearchTerms])) {
         results.push({ key: 'updates', label: tab.label, description: 'Check for stable or beta software update versions.', tab: 'updates', targetId: 'setting-updates' });
       }
@@ -422,14 +428,15 @@ export default function SettingsModal({
 
   const overallSearch = query.trim().toLowerCase();
   const showTheme = !overallSearch || overallExtraSearchTerms.some(term => term.includes(overallSearch) || overallSearch.includes(term));
+  const showAccent = !overallSearch || searchMatches(overallSearch, accentSearchTerms);
   const showUpdates = !overallSearch || updatesExtraSearchTerms.some(term => term.includes(overallSearch) || overallSearch.includes(term));
   const hasOverallDefinitions = definitions.some(definition => tabForDefinition(definition) === 'overall');
 
   const overall = <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-    {showTheme && <section className="settings-section" aria-labelledby="settings-appearance">
+    {(showTheme || showAccent) && <section className="settings-section" aria-labelledby="settings-appearance">
       <Divider orientation="left" plain><span id="settings-appearance">Appearance</span></Divider>
       <div className="settings-list">
-        <div className="settings-row" id="setting-theme" tabIndex={-1}>
+        {showTheme && <div className="settings-row" id="setting-theme" tabIndex={-1}>
           <div className="settings-copy">
             <Typography.Text strong>Theme</Typography.Text>
             <Typography.Text type="secondary">Choose the application color theme. This preference is applied immediately.</Typography.Text>
@@ -442,11 +449,12 @@ export default function SettingsModal({
                 onChange={event => onThemeChange(event.target.value === 'dark')} />
             </div>
           </div>
-        </div>
+        </div>}
+        {showAccent && <AccentColorSetting />}
       </div>
     </section>}
-    {definitionRows('overall', showTheme)}
-    {!showTheme && !hasOverallDefinitions && <Typography.Text type="secondary">No overall settings match this search.</Typography.Text>}
+    {definitionRows('overall', showTheme || showAccent)}
+    {!showTheme && !showAccent && !hasOverallDefinitions && <Typography.Text type="secondary">No overall settings match this search.</Typography.Text>}
   </Space>;
 
   const updatesSettings = <Space direction="vertical" size="middle" style={{ width: '100%' }}>

--- a/src/utils/accentColor.ts
+++ b/src/utils/accentColor.ts
@@ -1,0 +1,40 @@
+export const ACCENT_COLOR_STORAGE_KEY = 'quizzer.accent-color';
+export const ACCENT_COLOR_CHANGED_EVENT = 'quizzer:accent-color-changed';
+
+// Paired palettes keep primary text and filled controls readable in both themes.
+// Blue preserves the existing primary and selection colors.
+export const ACCENT_COLORS = [
+  { id: 'blue', label: 'Blue', light: { primary: '#0050b3', selected: '#e6f4ff' }, dark: { primary: '#69b1ff', selected: '#15395b' } },
+  { id: 'purple', label: 'Purple', light: { primary: '#531dab', selected: '#f9f0ff' }, dark: { primary: '#b37feb', selected: '#302044' } },
+  { id: 'green', label: 'Green', light: { primary: '#237804', selected: '#f6ffed' }, dark: { primary: '#95de64', selected: '#20351c' } },
+  { id: 'teal', label: 'Teal', light: { primary: '#006d75', selected: '#e6fffb' }, dark: { primary: '#5cdbd3', selected: '#153638' } },
+  { id: 'orange', label: 'Orange', light: { primary: '#ad4e00', selected: '#fff7e6' }, dark: { primary: '#ffc069', selected: '#3e2b19' } },
+  { id: 'magenta', label: 'Magenta', light: { primary: '#9e1068', selected: '#fff0f6' }, dark: { primary: '#ff85c0', selected: '#421f34' } },
+] as const;
+
+export type AccentColor = typeof ACCENT_COLORS[number]['id'];
+export const DEFAULT_ACCENT_COLOR: AccentColor = 'blue';
+
+export function normalizeAccentColor(value: unknown): AccentColor {
+  return ACCENT_COLORS.find(color => color.id === value)?.id ?? DEFAULT_ACCENT_COLOR;
+}
+
+export function getAccentPalette(color: AccentColor, dark: boolean) {
+  const option = ACCENT_COLORS.find(candidate => candidate.id === color) ?? ACCENT_COLORS[0];
+  return { ...option[dark ? 'dark' : 'light'], onPrimary: dark ? '#101214' : '#ffffff' };
+}
+
+export function loadAccentColor(storage?: Pick<Storage, 'getItem'>): AccentColor {
+  try {
+    return normalizeAccentColor((storage ?? localStorage).getItem(ACCENT_COLOR_STORAGE_KEY));
+  } catch {
+    // A denied/unavailable browser store must not prevent the app from opening.
+    return DEFAULT_ACCENT_COLOR;
+  }
+}
+
+export function saveAccentColor(color: AccentColor, storage?: Pick<Storage, 'setItem'>): void {
+  if (!ACCENT_COLORS.some(option => option.id === color)) throw new Error('Unknown accent color');
+  // Let the caller report failure rather than claiming a preference was saved.
+  (storage ?? localStorage).setItem(ACCENT_COLOR_STORAGE_KEY, color);
+}

--- a/src/utils/useAccentColor.ts
+++ b/src/utils/useAccentColor.ts
@@ -1,0 +1,30 @@
+import { useSyncExternalStore } from 'react';
+import {
+  ACCENT_COLOR_CHANGED_EVENT,
+  ACCENT_COLOR_STORAGE_KEY,
+  DEFAULT_ACCENT_COLOR,
+  loadAccentColor,
+  saveAccentColor,
+  type AccentColor,
+} from './accentColor';
+
+function subscribe(onChange: () => void) {
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === ACCENT_COLOR_STORAGE_KEY || event.key === null) onChange();
+  };
+  window.addEventListener(ACCENT_COLOR_CHANGED_EVENT, onChange);
+  window.addEventListener('storage', onStorage);
+  return () => {
+    window.removeEventListener(ACCENT_COLOR_CHANGED_EVENT, onChange);
+    window.removeEventListener('storage', onStorage);
+  };
+}
+
+export function useAccentColor() {
+  return useSyncExternalStore(subscribe, loadAccentColor, () => DEFAULT_ACCENT_COLOR);
+}
+
+export function changeAccentColor(color: AccentColor) {
+  saveAccentColor(color);
+  window.dispatchEvent(new Event(ACCENT_COLOR_CHANGED_EVENT));
+}

--- a/test/accent-color.test.mjs
+++ b/test/accent-color.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ACCENT_COLORS,
+  ACCENT_COLOR_STORAGE_KEY,
+  DEFAULT_ACCENT_COLOR,
+  getAccentPalette,
+  loadAccentColor,
+  normalizeAccentColor,
+  saveAccentColor,
+} from '../src/utils/accentColor.ts';
+
+const luminance = hex => {
+  const rgb = hex.slice(1).match(/../g).map(channel => {
+    const value = parseInt(channel, 16) / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return rgb[0] * 0.2126 + rgb[1] * 0.7152 + rgb[2] * 0.0722;
+};
+const contrast = (first, second) => {
+  const values = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (values[0] + 0.05) / (values[1] + 0.05);
+};
+
+test('recognizes every named accent and defaults invalid persisted values to blue', () => {
+  assert.equal(new Set(ACCENT_COLORS.map(color => color.id)).size, ACCENT_COLORS.length);
+  for (const color of ACCENT_COLORS) assert.equal(normalizeAccentColor(color.id), color.id);
+  for (const value of [null, undefined, '', 'unknown', '#ff0000', 42, {}, '__proto__']) {
+    assert.equal(normalizeAccentColor(value), DEFAULT_ACCENT_COLOR);
+    assert.equal(loadAccentColor({ getItem: () => value }), DEFAULT_ACCENT_COLOR);
+  }
+});
+
+test('round-trips each accent without overwriting other preferences', () => {
+  const saved = new Map([['quizzer.theme', 'dark']]);
+  const storage = { getItem: key => saved.get(key) ?? null, setItem: (key, value) => saved.set(key, value) };
+  for (const color of ACCENT_COLORS) {
+    saveAccentColor(color.id, storage);
+    assert.equal(saved.get(ACCENT_COLOR_STORAGE_KEY), color.id);
+    assert.equal(loadAccentColor(storage), color.id);
+  }
+  saveAccentColor(DEFAULT_ACCENT_COLOR, storage);
+  assert.equal(loadAccentColor(storage), 'blue');
+  assert.equal(saved.get('quizzer.theme'), 'dark');
+});
+
+test('survives blocked reads but reports failed writes and rejects invalid choices', () => {
+  assert.equal(loadAccentColor({ getItem() { throw new Error('denied'); } }), 'blue');
+  assert.throws(() => saveAccentColor('purple', { setItem() { throw new Error('quota'); } }), /quota/);
+  assert.throws(() => saveAccentColor('invalid', { setItem() { assert.fail('must not write'); } }), /Unknown accent/);
+});
+
+test('preserves the original blue primary and selected backgrounds', () => {
+  assert.deepEqual(getAccentPalette('blue', false), { primary: '#0050b3', selected: '#e6f4ff', onPrimary: '#ffffff' });
+  assert.deepEqual(getAccentPalette('blue', true), { primary: '#69b1ff', selected: '#15395b', onPrimary: '#101214' });
+});
+
+test('all accent palettes have readable text, controls and selection backgrounds', () => {
+  for (const color of ACCENT_COLORS) for (const dark of [false, true]) {
+    const palette = getAccentPalette(color.id, dark);
+    const surfaces = dark ? ['#101214', '#17191c', '#202328', '#1c1f23'] : ['#ffffff', '#f5f7fa', '#f0f2f5', '#f5f5f7'];
+    for (const surface of surfaces) assert.ok(contrast(palette.primary, surface) >= 4.5, `${color.id} primary on ${surface}`);
+    assert.ok(contrast(palette.primary, palette.onPrimary) >= 4.5, `${color.id} filled text`);
+    assert.ok(contrast(dark ? '#e6e8eb' : '#1f2328', palette.selected) >= 4.5, `${color.id} selected text`);
+    assert.ok(contrast(palette.primary, palette.selected) >= 4.5, `${color.id} selected accent text`);
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #93.

- Add Blue, Purple, Green, Teal, Orange and Magenta choices under Settings > Overall > Appearance, with an accessible named selector and reset-to-blue control.
- Apply changes immediately without saving server settings, persist the preference locally, and synchronize it between open windows.
- Use paired light/dark palettes for Ant Design primary controls and links, plus custom selection backgrounds, focus indicators, onboarding highlights and chat accents.
- Keep semantic success, warning, error and question-category colors unchanged. No plugin installation/configuration behavior changes.
- Include the accent preference in Settings search, including palette names.
- Default invalid/unreadable preferences to Blue and show an error when a write fails rather than applying an unsaved choice.

## Commits
1. Implement the preference, Settings integration and application styling.
2. Add unit and browser regression coverage.

## Validation
Passed locally:
- 5 Node unit tests covering all six choices, persistence/reset, invalid data, storage failures, original Blue compatibility and text contrast in light/dark palettes.
- Strict TypeScript checking of the standalone palette/persistence utility.
- TypeScript transpilation/syntax checks for all changed TS/TSX files and the new Playwright spec.
- CSS parsing and inspection of the focused application/Settings diff; uploaded application and Settings blobs match the checked local files.

Added 4 Playwright scenarios for immediate application/theme switching/reload/reset, Settings search and keyboard selection, cross-window synchronization, and failed saves. Full repository lint/build/browser tests were not runnable locally because the sandbox cannot clone/install dependencies; repository CI is required before merging.

## Compatibility
Independent branch from develop; does not include PR #98. No dependencies, migrations or provider/model changes. The existing Blue primary and selected-background colors remain the default.