### PR TITLE
fix(modals): keep long modal content internally scrollable

### DIFF
--- a/e2e/plugins-modal.spec.ts
+++ b/e2e/plugins-modal.spec.ts
@@ -41,6 +41,18 @@ test('Plugins & models exposes capability tabs without inline settings dropdowns
   await expect(ollamaSettings.getByText('Resource limits')).toHaveCount(0);
 });
 
+test('Plugins & models keeps detection in the title and does not expose local plugin installation', async ({ page }) => {
+  await dismissOnboarding(page);
+  await setInterfaceMode(page, 'advanced');
+  await page.getByRole('button', { name: 'Configure AI' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Plugins & models' });
+  await expect(dialog.getByRole('button', { name: 'Detect plugins and models again' })).toBeVisible();
+  await expect(dialog.getByText('Choose a capability, then enable a detected option or install one.')).toHaveCount(0);
+  await expect(dialog.getByRole('button', { name: 'Install local plugin' })).toHaveCount(0);
+  await expect(dialog.getByRole('button', { name: 'Detect again', exact: true })).toHaveCount(0);
+});
+
 test('uninstalled plugin and provider options do not show enable switches', async ({ page }) => {
   await page.route('**/api/integrations', route => route.fulfill({
     contentType: 'application/json',

--- a/src/components/PluginsModal.tsx
+++ b/src/components/PluginsModal.tsx
@@ -3,9 +3,8 @@ import { Alert, Button, Divider, Empty, Input, InputNumber, Modal, Space, Spin, 
 import { formatErrorMessage } from '../utils/errorFormatting';
 import { ErrorDisplay } from './ErrorDisplay';
 import {
-  ApiOutlined, CloudDownloadOutlined, DeleteOutlined, FileSearchOutlined, FolderOpenOutlined,
-  LoginOutlined, ReloadOutlined, RobotOutlined, RollbackOutlined, ScanOutlined, SettingOutlined,
-  ShareAltOutlined,
+  ApiOutlined, CloudDownloadOutlined, DeleteOutlined, FileSearchOutlined, LoginOutlined, ReloadOutlined,
+  RobotOutlined, RollbackOutlined, ScanOutlined, SettingOutlined, ShareAltOutlined,
 } from '@ant-design/icons';
 import type { GenerationProvider, InterfaceMode } from '../types';
 import {
@@ -369,22 +368,6 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         await refresh();
       },
     });
-  };
-
-  const installExternalPlugin = async () => {
-    if (!window.quizzerDesktop) return;
-    const path = await window.quizzerDesktop.selectPluginDirectory();
-    if (!path) return;
-    setPluginAction('install');
-    try {
-      const result = await serviceJson<{ plugin: ExternalPlugin }>('/api/v1/plugins/install', 'POST', { path });
-      message.success(`${result.plugin.name ?? result.plugin.id} installed`);
-      await refreshExternal();
-    } catch (error) {
-      message.error(formatErrorMessage(error, 'plugin'));
-    } finally {
-      setPluginAction('');
-    }
   };
 
   const runExternalAction = async (plugin: ExternalPlugin, action: 'enable' | 'disable' | 'health' | 'rollback') => {
@@ -849,18 +832,10 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
 
   return (
     <>
-      <Modal open title={<Space><ApiOutlined /> Plugins & models</Space>} width={940} onCancel={onClose} onOk={() => void save()}
+      <Modal open title={<Space><ApiOutlined /> Plugins & models <Button type="text" size="small" icon={<ReloadOutlined />}
+        loading={externalLoading} aria-label="Detect plugins and models again"
+        onClick={() => { void refresh(); void refreshExternal(); }} /></Space>} width={940} onCancel={onClose} onOk={() => void save()}
         confirmLoading={saving} okButtonProps={{ disabled: !credentialReady }} okText="Save settings">
-        <div className="plugin-modal-intro">
-          <Typography.Text type="secondary">Choose a capability, then enable a detected option or install one. Configuration stays behind each option’s Settings button.</Typography.Text>
-          <Space wrap>
-            <Button size="small" icon={<FolderOpenOutlined />} loading={pluginAction === 'install'}
-              disabled={interfaceMode !== 'advanced' || !window.quizzerDesktop || Boolean(pluginAction)}
-              onClick={() => void installExternalPlugin()}>Install local plugin</Button>
-            <Button size="small" icon={<ReloadOutlined />} loading={externalLoading}
-              onClick={() => { void refresh(); void refreshExternal(); }}>Detect again</Button>
-          </Space>
-        </div>
         {interfaceMode !== 'advanced' ? <Typography.Text type="secondary">Advanced mode is required to install third-party plugins.</Typography.Text> : null}
         {statusError ? <Space direction="vertical"><ErrorDisplay error={statusError} context="plugin" /><Button size="small" onClick={() => void refresh()}>Retry detection</Button></Space> : null}
         {externalError ? <Space direction="vertical"><ErrorDisplay error={externalError} context="plugin" /><Button size="small" onClick={() => void refreshExternal()}>Retry plugins</Button></Space> : null}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './modal-overflow.css'
 import App from './App.tsx'
 import 'antd/dist/reset.css';
 import { initializeServerSync } from './db/serverSync.ts';

--- a/src/modal-overflow.css
+++ b/src/modal-overflow.css
@@ -1,0 +1,26 @@
+.ant-modal-wrap {
+  overflow: hidden;
+}
+
+.ant-modal {
+  max-height: calc(100dvh - 32px);
+  padding-bottom: 0;
+}
+
+.ant-modal-content {
+  max-height: calc(100dvh - 32px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ant-modal-body {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.ant-modal-header,
+.ant-modal-footer {
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
Closes #89.

- bounds modal content to the viewport
- keeps headers and footers fixed while the modal body scrolls
- prevents Plugins & Models and Activity from lengthening the app page
- applies the behavior consistently to long Ant Design modals