### PR TITLE
feat(plugins): use themed icons for plugins and models

### DIFF
--- a/e2e/plugins-modal.spec.ts
+++ b/e2e/plugins-modal.spec.ts
@@ -41,6 +41,18 @@ test('Plugins & models exposes capability tabs without inline settings dropdowns
   await expect(ollamaSettings.getByText('Resource limits')).toHaveCount(0);
 });
 
+test('Plugins & models keeps detection in the title and does not expose local plugin installation', async ({ page }) => {
+  await dismissOnboarding(page);
+  await setInterfaceMode(page, 'advanced');
+  await page.getByRole('button', { name: 'Configure AI' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Plugins & models' });
+  await expect(dialog.getByRole('button', { name: 'Detect plugins and models again' })).toBeVisible();
+  await expect(dialog.getByText('Choose a capability, then enable a detected option or install one.')).toHaveCount(0);
+  await expect(dialog.getByRole('button', { name: 'Install local plugin' })).toHaveCount(0);
+  await expect(dialog.getByRole('button', { name: 'Detect again', exact: true })).toHaveCount(0);
+});
+
 test('uninstalled plugin and provider options do not show enable switches', async ({ page }) => {
   await page.route('**/api/integrations', route => route.fulfill({
     contentType: 'application/json',

--- a/src/components/PluginsModal.tsx
+++ b/src/components/PluginsModal.tsx
@@ -3,9 +3,8 @@ import { Alert, Button, Divider, Empty, Input, InputNumber, Modal, Space, Spin, 
 import { formatErrorMessage } from '../utils/errorFormatting';
 import { ErrorDisplay } from './ErrorDisplay';
 import {
-  ApiOutlined, CloudDownloadOutlined, DeleteOutlined, FileSearchOutlined, FolderOpenOutlined,
-  LoginOutlined, ReloadOutlined, RobotOutlined, RollbackOutlined, ScanOutlined, SettingOutlined,
-  ShareAltOutlined,
+  ApiOutlined, CloudDownloadOutlined, DeleteOutlined, FileSearchOutlined, LoginOutlined, ReloadOutlined,
+  RobotOutlined, RollbackOutlined, ScanOutlined, SettingOutlined, ShareAltOutlined,
 } from '@ant-design/icons';
 import type { GenerationProvider, InterfaceMode } from '../types';
 import {
@@ -369,22 +368,6 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         await refresh();
       },
     });
-  };
-
-  const installExternalPlugin = async () => {
-    if (!window.quizzerDesktop) return;
-    const path = await window.quizzerDesktop.selectPluginDirectory();
-    if (!path) return;
-    setPluginAction('install');
-    try {
-      const result = await serviceJson<{ plugin: ExternalPlugin }>('/api/v1/plugins/install', 'POST', { path });
-      message.success(`${result.plugin.name ?? result.plugin.id} installed`);
-      await refreshExternal();
-    } catch (error) {
-      message.error(formatErrorMessage(error, 'plugin'));
-    } finally {
-      setPluginAction('');
-    }
   };
 
   const runExternalAction = async (plugin: ExternalPlugin, action: 'enable' | 'disable' | 'health' | 'rollback') => {
@@ -849,18 +832,10 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
 
   return (
     <>
-      <Modal open title={<Space><ApiOutlined /> Plugins & models</Space>} width={940} onCancel={onClose} onOk={() => void save()}
+      <Modal open title={<Space><ApiOutlined /> Plugins & models <Button type="text" size="small" icon={<ReloadOutlined />}
+        loading={externalLoading} aria-label="Detect plugins and models again"
+        onClick={() => { void refresh(); void refreshExternal(); }} /></Space>} width={940} onCancel={onClose} onOk={() => void save()}
         confirmLoading={saving} okButtonProps={{ disabled: !credentialReady }} okText="Save settings">
-        <div className="plugin-modal-intro">
-          <Typography.Text type="secondary">Choose a capability, then enable a detected option or install one. Configuration stays behind each option’s Settings button.</Typography.Text>
-          <Space wrap>
-            <Button size="small" icon={<FolderOpenOutlined />} loading={pluginAction === 'install'}
-              disabled={interfaceMode !== 'advanced' || !window.quizzerDesktop || Boolean(pluginAction)}
-              onClick={() => void installExternalPlugin()}>Install local plugin</Button>
-            <Button size="small" icon={<ReloadOutlined />} loading={externalLoading}
-              onClick={() => { void refresh(); void refreshExternal(); }}>Detect again</Button>
-          </Space>
-        </div>
         {interfaceMode !== 'advanced' ? <Typography.Text type="secondary">Advanced mode is required to install third-party plugins.</Typography.Text> : null}
         {statusError ? <Space direction="vertical"><ErrorDisplay error={statusError} context="plugin" /><Button size="small" onClick={() => void refresh()}>Retry detection</Button></Space> : null}
         {externalError ? <Space direction="vertical"><ErrorDisplay error={externalError} context="plugin" /><Button size="small" onClick={() => void refreshExternal()}>Retry plugins</Button></Space> : null}

--- a/src/components/PluginsModal.tsx
+++ b/src/components/PluginsModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { Alert, Button, Divider, Empty, Input, InputNumber, Modal, Space, Spin, Switch, Tabs, Tag, Typography } from 'antd';
+import { Alert, Button, Divider, Empty, Input, InputNumber, Modal, Space, Switch, Tabs, Tag, Typography } from 'antd';
 import { formatErrorMessage } from '../utils/errorFormatting';
 import { ErrorDisplay } from './ErrorDisplay';
 import {
@@ -15,6 +15,7 @@ import {
 import { getMessageApi } from '../utils/messageProvider';
 import { getModalApi } from '../utils/modalProvider';
 import { executeTwoPhaseAction, serviceFetch, serviceJson, serviceRequest } from '../utils/serviceApi';
+import { IntegrationStatusGate, PluginGlyph, PluginJobDetails } from './pluginOptionPresentation';
 
 type JobState = 'idle' | 'working' | 'complete' | 'error';
 type AgentStatus = { installed: boolean; connected: boolean; job?: { state: JobState; message: string } };
@@ -128,10 +129,11 @@ interface IntegrationOptionProps {
 function IntegrationOption({
   icon, title, description, state, checked, switchLabel, switchDisabled, showSwitch = true, onToggle, actions, details, warning,
 }: IntegrationOptionProps) {
+  const working = /installing|working/i.test(state);
   return (
     <section className={`plugin-option${warning ? ' plugin-option-warning' : ''}`}>
       <div className="plugin-option-main">
-        <span className="plugin-option-icon" aria-hidden="true">{icon}</span>
+        <span className="plugin-option-icon" aria-hidden="true"><PluginGlyph title={title} fallback={icon} /></span>
         <div className="plugin-option-copy">
           <Typography.Text strong>{title}</Typography.Text>
           <Typography.Text type="secondary">{description}</Typography.Text>
@@ -142,7 +144,7 @@ function IntegrationOption({
           {onToggle && showSwitch ? <Switch checked={checked} disabled={switchDisabled} onChange={onToggle} aria-label={switchLabel ?? `Enable ${title}`} /> : null}
         </Space>
       </div>
-      {details ? <div className="plugin-option-details">{details}</div> : null}
+      {details ? <div className="plugin-option-details"><PluginJobDetails working={working}>{details}</PluginJobDetails></div> : null}
     </section>
   );
 }
@@ -839,14 +841,14 @@ export default function PluginsModal({ interfaceMode, onClose }: Props) {
         {interfaceMode !== 'advanced' ? <Typography.Text type="secondary">Advanced mode is required to install third-party plugins.</Typography.Text> : null}
         {statusError ? <Space direction="vertical"><ErrorDisplay error={statusError} context="plugin" /><Button size="small" onClick={() => void refresh()}>Retry detection</Button></Space> : null}
         {externalError ? <Space direction="vertical"><ErrorDisplay error={externalError} context="plugin" /><Button size="small" onClick={() => void refreshExternal()}>Retry plugins</Button></Space> : null}
-        {!status && !statusError ? <div className="plugin-loading"><Spin /></div> : (
+        <IntegrationStatusGate loading={!status && !statusError}>
           <Tabs defaultActiveKey="document-extraction" items={[
             { key: 'document-extraction', label: 'Document extraction', children: documentTab },
             { key: 'image-ocr', label: 'Image OCR', children: ocrTab },
             { key: 'embeddings', label: 'Embeddings', children: embeddingsTab },
             { key: 'models', label: 'Models', children: modelsTab },
           ]} />
-        )}
+        </IntegrationStatusGate>
       </Modal>
 
       <Modal open={Boolean(modelSettingsProvider)}

--- a/src/components/pluginOptionPresentation.tsx
+++ b/src/components/pluginOptionPresentation.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+import { Spin } from 'antd';
+import {
+  ApiOutlined, CodeOutlined, DatabaseOutlined, DesktopOutlined, FileSearchOutlined, GlobalOutlined,
+  GoogleOutlined, MessageOutlined, OpenAIOutlined, RocketOutlined, RobotOutlined, ScanOutlined,
+  SearchOutlined, SortAscendingOutlined, ApartmentOutlined,
+} from '@ant-design/icons';
+
+const normalized = (value: string) => value.toLowerCase();
+
+export function PluginGlyph({ title, fallback }: { title: string; fallback: ReactNode }) {
+  const name = normalized(title);
+  if (name.includes('openai')) return <OpenAIOutlined />;
+  if (name.includes('gemini')) return <GoogleOutlined />;
+  if (name.includes('ollama')) return <DesktopOutlined />;
+  if (name.includes('llama.cpp')) return <CodeOutlined />;
+  if (name.includes('codex')) return <CodeOutlined />;
+  if (name.includes('antigravity')) return <RocketOutlined />;
+  if (name.includes('claude') || name.includes('anthropic')) return <MessageOutlined />;
+  if (name.includes('openrouter')) return <GlobalOutlined />;
+  if (name.includes('deepseek')) return <SearchOutlined />;
+  if (name.includes('rapidocr') || name.includes('ocr')) return <ScanOutlined />;
+  if (name.includes('document extraction') || name.includes('marker')) return <FileSearchOutlined />;
+  if (name.includes('embedding')) return <ApartmentOutlined />;
+  if (name.includes('vector index') || name.includes('lancedb')) return <DatabaseOutlined />;
+  if (name.includes('reranker') || name.includes('reranking')) return <SortAscendingOutlined />;
+  if (name.includes('generator')) return <RobotOutlined />;
+  if (name.includes('compatible') || name.includes('plugin')) return <ApiOutlined />;
+  return <>{fallback}</>;
+}
+
+export function PluginJobDetails({ children }: { children: ReactNode; working: boolean }) {
+  return <>{children}</>;
+}
+
+export function IntegrationStatusGate({ loading, children }: { loading: boolean; children: ReactNode }) {
+  return loading ? <div className="plugin-loading"><Spin /></div> : <>{children}</>;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './modal-overflow.css'
 import App from './App.tsx'
 import 'antd/dist/reset.css';
 import { initializeServerSync } from './db/serverSync.ts';

--- a/src/modal-overflow.css
+++ b/src/modal-overflow.css
@@ -1,0 +1,26 @@
+.ant-modal-wrap {
+  overflow: hidden;
+}
+
+.ant-modal {
+  max-height: calc(100dvh - 32px);
+  padding-bottom: 0;
+}
+
+.ant-modal-content {
+  max-height: calc(100dvh - 32px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ant-modal-body {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.ant-modal-header,
+.ant-modal-footer {
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
Closes #92.

- maps known providers and capabilities to specific monochrome Ant Design icons
- uses OpenAI/Google glyphs where the installed icon set provides them
- differentiates local runtimes, agents, OCR, embeddings, vector indexes, and reranking
- keeps the existing supplied icon as the fallback for unknown plugins