### PR TITLE
perf(plugins): render Plugins & Models before detection completes

### DIFF
--- a/src/components/pluginOptionPresentation.tsx
+++ b/src/components/pluginOptionPresentation.tsx
@@ -39,5 +39,10 @@ export function PluginJobDetails({ children, working }: { children: ReactNode; w
 }
 
 export function IntegrationStatusGate({ loading, children }: { loading: boolean; children: ReactNode }) {
-  return loading ? <div className="plugin-loading"><Spin /></div> : <>{children}</>;
+  return (
+    <Space direction="vertical" size="small" style={{ width: '100%' }}>
+      {loading ? <Space size="small" className="plugin-detection-status"><Spin size="small" /><Typography.Text type="secondary">Detecting installed tools and models…</Typography.Text></Space> : null}
+      {children}
+    </Space>
+  );
 }


### PR DESCRIPTION
Closes #88.

- renders capability tabs immediately from known settings
- moves integration detection to a small non-blocking status indicator
- keeps detection asynchronous so slow local CLI probes no longer hold the modal UI behind a full spinner