### PR TITLE
fix(accessibility): keep command palette contrast compliant

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -4,6 +4,8 @@ import { dismissOnboarding, setInterfaceMode } from './helpers';
 
 const wcagTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'];
 
+test.describe.configure({ retries: 0 });
+
 const expectNoWcagViolations = async (page: Page) => {
   await expect(page.locator('[class*="-appear-active"]:visible, [class*="-enter-active"]:visible')).toHaveCount(0);
   const { violations } = await new AxeBuilder({ page }).withTags(wcagTags).analyze();

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -54,7 +54,7 @@ export default function CommandPalette({ open, commands, onClose }: Props) {
             <span className="command-palette-icon" aria-hidden="true">{command.icon}</span>
             <span>
               <Typography.Text strong>{command.label}</Typography.Text>
-              <Typography.Text type="secondary">{command.description}</Typography.Text>
+              <Typography.Text style={{ color: 'var(--text-muted)' }}>{command.description}</Typography.Text>
             </span>
             {command.shortcut && <Tag>{command.shortcut}</Tag>}
           </button>


### PR DESCRIPTION
## Summary

- use Quizzer's accessible muted text token for Command Palette descriptions instead of Ant Design's secondary-text styling
- make the WCAG accessibility suite non-retriable in CI so serious accessibility failures cannot be hidden as flaky-green results

## Context

The `v1.0.0-beta.9` release verification recorded a serious `color-contrast` violation while the Command Palette was open. Playwright retried the test and the workflow passed with `1 flaky`, which masked the first-attempt failure. The beta.9 release was cancelled before publication.

## Verification

GitHub CI must pass on this exact PR head. The application E2E log should report the accessibility suite passing without retries or flaky annotations.