### PR TITLE
Allow active plugin installations to be cancelled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import AddTestModal from './components/AddTestModal';
 import AddDocumentModal from './components/AddDocumentModal';
 import DocumentView from './components/DocumentView';
 import PluginsModal from './components/PluginsModal';
+import PluginInstallCancellation from './components/PluginInstallCancellation';
 import SettingsModal from './components/SettingsModal';
 import CommandPalette, { type PaletteCommand } from './components/CommandPalette';
 import GenerationWorker from './components/GenerationWorker';
@@ -135,6 +136,7 @@ function AppShell({ dark, onThemeChange }: ShellProps) {
 
   return <>
     <GenerationWorker />
+    <PluginInstallCancellation />
     <UpdateAvailableNotifier
       isTestActive={session?.mode === 'taking'}
       onOpenSettings={openUpdateSettings}

--- a/src/components/PluginInstallCancellation.tsx
+++ b/src/components/PluginInstallCancellation.tsx
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from 'react';
+import { Button } from 'antd';
+import { StopOutlined } from '@ant-design/icons';
+import { cancelActivePluginInstall, isPluginInstallActive, subscribePluginInstallState } from '../utils/serviceApi';
+
+export default function PluginInstallCancellation() {
+  const active = useSyncExternalStore(subscribePluginInstallState, isPluginInstallActive, () => false);
+  if (!active) return null;
+
+  return (
+    <div role="status" aria-live="polite" style={{ position: 'fixed', right: 20, bottom: 20, zIndex: 2100 }}>
+      <Button danger type="primary" icon={<StopOutlined />} onClick={() => cancelActivePluginInstall()}>
+        Cancel plugin installation
+      </Button>
+    </div>
+  );
+}

--- a/src/utils/serviceApi.ts
+++ b/src/utils/serviceApi.ts
@@ -38,10 +38,34 @@ export const serviceAuthorizationHeader = () => {
 };
 
 let integrationActionTrigger: HTMLButtonElement | null = null;
+let activePluginInstall: AbortController | null = null;
+const pluginInstallListeners = new Set<() => void>();
+
+const emitPluginInstallState = () => {
+  for (const listener of pluginInstallListeners) listener();
+};
+
+export const subscribePluginInstallState = (listener: () => void) => {
+  pluginInstallListeners.add(listener);
+  return () => pluginInstallListeners.delete(listener);
+};
+
+export const isPluginInstallActive = () => activePluginInstall !== null;
+
+export const cancelActivePluginInstall = () => {
+  if (!activePluginInstall) return false;
+  activePluginInstall.abort(new DOMException('Plugin installation cancelled', 'AbortError'));
+  return true;
+};
 
 const isIntegrationMutation = (path: string, init: RequestInit) => {
   const method = (init.method ?? 'GET').toUpperCase();
   return method === 'POST' && /^\/api\/(?:v1\/)?integrations\/.+\/(?:install|connect|pull)$/.test(path);
+};
+
+const isRegistryPluginInstall = (path: string, init: RequestInit) => {
+  const method = (init.method ?? 'GET').toUpperCase();
+  return method === 'POST' && path === '/api/v1/plugins/install';
 };
 
 const guardIntegrationTrigger = () => {
@@ -69,14 +93,35 @@ export const serviceFetch = async (path: string, init: RequestInit = {}) => {
   const authorization = serviceAuthorizationHeader();
   if (authorization && !headers.has('Authorization')) headers.set('Authorization', authorization);
   const guardedMutation = isIntegrationMutation(path, init);
+  const registryInstall = isRegistryPluginInstall(path, init);
   if (guardedMutation) guardIntegrationTrigger();
+
+  let installController: AbortController | undefined;
+  let forwardedAbort: (() => void) | undefined;
+  if (registryInstall) {
+    installController = new AbortController();
+    if (init.signal) {
+      forwardedAbort = () => installController?.abort(init.signal?.reason);
+      if (init.signal.aborted) forwardedAbort();
+      else init.signal.addEventListener('abort', forwardedAbort, { once: true });
+    }
+    activePluginInstall = installController;
+    emitPluginInstallState();
+  }
+
   try {
-    const response = await fetch(path, { ...init, headers });
+    const response = await fetch(path, { ...init, headers, ...(installController ? { signal: installController.signal } : {}) });
     if (path === '/api/integrations' || (guardedMutation && !response.ok)) releaseIntegrationTrigger();
     return response;
   } catch (error) {
     if (guardedMutation || path === '/api/integrations') releaseIntegrationTrigger();
     throw error;
+  } finally {
+    if (forwardedAbort && init.signal) init.signal.removeEventListener('abort', forwardedAbort);
+    if (installController && activePluginInstall === installController) {
+      activePluginInstall = null;
+      emitPluginInstallState();
+    }
   }
 };
 
@@ -117,7 +162,7 @@ export const serviceJson = async <Response>(
   // The embedding installer deliberately rejects a model that differs from the
   // current resolved setting. Make a confirmed download authoritative by
   // selecting that model first, so a cached Plugins & Models snapshot cannot
-  // turn a valid bge-m3 click into a stale-model rejection.
+  // turn a valid bge-m3 click into a silent stale-model rejection.
   if (path === '/api/integrations/embeddings/install' && method === 'POST' && body && typeof body === 'object') {
     const model = (body as { model?: unknown }).model;
     const confirmed = (body as { confirmed?: unknown }).confirmed;
@@ -138,9 +183,6 @@ export const serviceJson = async <Response>(
   };
   if (path.startsWith('/api/v1/')) return serviceRequest<Response>(path, requestInit);
 
-  // Some built-in integration endpoints predate /api/v1. Keep serviceRequest's
-  // stricter v1-only contract while still sending these authenticated JSON
-  // mutations through serviceFetch and the same structured response parser.
   const headers = new Headers(requestInit.headers);
   if (requestInit.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
   const response = await serviceFetch(path, { ...requestInit, headers });


### PR DESCRIPTION
Fixes #113.

- attach an AbortController to active signed-registry plugin installation requests
- forward cancellation through the existing server request-lifetime signal, so PluginManager installation work is actually aborted
- expose install activity as a small external-store API
- show a visible “Cancel plugin installation” action while the install request is active
- preserve caller-provided AbortSignals and clean up listeners/controllers after completion

Stacked on #117 so this PR contains only the #113 delta.