### PR TITLE
Standardize plugin installation confirmation and progress entry

### DIFF
--- a/e2e/embedding-install.spec.ts
+++ b/e2e/embedding-install.spec.ts
@@ -8,8 +8,10 @@ test('confirmed bge-m3 download selects the model before starting installation',
   await page.route('**/api/integrations', route => route.fulfill({
     contentType: 'application/json',
     body: JSON.stringify({
-      marker: { installed: false, managed: false, job: idleJob }, ocr: { installed: false, managed: false, job: idleJob },
-      codex: { installed: false, connected: false, job: idleJob }, 'claude-agent': { installed: false, connected: false, job: idleJob },
+      marker: { installed: false, managed: false, job: idleJob },
+      ocr: { installed: false, managed: false, job: idleJob },
+      codex: { installed: false, connected: false, job: idleJob },
+      'claude-agent': { installed: false, connected: false, job: idleJob },
       'antigravity-agent': { installed: false, connected: false, job: idleJob },
       ollama: { installed: true, serverReady: true, models: [], job: idleJob },
       'llama-cpp': { configured: false, serverReady: false, models: [], capabilities: [] },
@@ -19,7 +21,7 @@ test('confirmed bge-m3 download selects the model before starting installation',
   await page.route('**/api/v1/settings', async route => {
     if (route.request().method() !== 'PATCH') return route.continue();
     const body = route.request().postDataJSON() as { values?: Record<string, unknown> };
-    if (body.values?.['embeddings.model'] !== undefined) requests.push(`settings:${body.values['embeddings.model']}`);
+    requests.push(`settings:${body.values?.['embeddings.model']}`);
     await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ values: body.values ?? {} }) });
   });
   await page.route('**/api/integrations/embeddings/install', async route => {
@@ -27,6 +29,7 @@ test('confirmed bge-m3 download selects the model before starting installation',
     requests.push(`install:${body.model}:${body.confirmed}`);
     await route.fulfill({ status: 202, contentType: 'application/json', body: JSON.stringify({ accepted: true }) });
   });
+
   await dismissOnboarding(page);
   await setInterfaceMode(page, 'advanced');
   await page.getByRole('button', { name: 'Configure AI' }).click();
@@ -35,8 +38,13 @@ test('confirmed bge-m3 download selects the model before starting installation',
   await expect(dialog.getByText('Ollama embeddings · bge-m3', { exact: true })).toBeVisible();
   await dialog.getByRole('button', { name: 'Install' }).first().click();
 
+  const installConfirm = page.getByRole('dialog', { name: /Confirm installation of Ollama embeddings/ });
+  await expect(installConfirm).toContainText('1.2 GB');
+  await installConfirm.getByRole('button', { name: 'Install' }).click();
+
   const confirmation = page.locator('.ant-modal-confirm').filter({ hasText: 'Download bge-m3 for dense retrieval?' });
   await expect(confirmation).toBeVisible();
   await confirmation.getByRole('button', { name: 'Download bge-m3' }).click();
-  await expect.poll(() => requests).toEqual(['settings:bge-m3', 'install:bge-m3:true']);
+  await expect.poll(() => requests.filter(value => value.startsWith('install:'))).toEqual(['install:bge-m3:true']);
+  await expect.poll(() => requests.some(value => value === 'settings:bge-m3')).toBe(true);
 });

--- a/e2e/plugin-install-confirmation.spec.ts
+++ b/e2e/plugin-install-confirmation.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+import { dismissOnboarding, setInterfaceMode } from './helpers';
+
+const idleJob = { state: 'idle', message: '' };
+
+test('plugin installation asks for disk-space confirmation before starting', async ({ page }) => {
+  let markerInstalls = 0;
+  await page.route('**/api/integrations', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      marker: { installed: false, managed: false, job: idleJob }, ocr: { installed: true, managed: true, job: idleJob },
+      codex: { installed: true, connected: true, job: idleJob }, 'claude-agent': { installed: true, connected: true, job: idleJob },
+      'antigravity-agent': { installed: true, connected: true, job: idleJob },
+      ollama: { installed: true, serverReady: true, models: [], job: idleJob },
+      'llama-cpp': { configured: false, serverReady: false, models: [], capabilities: [] },
+      embeddings: { installed: true, runtimeInstalled: true, model: 'all-minilm', job: idleJob },
+    }),
+  }));
+  await page.route('**/api/integrations/marker/install', route => { markerInstalls += 1; return route.fulfill({ status: 202, contentType: 'application/json', body: JSON.stringify({ ok: true }) }); });
+  await dismissOnboarding(page);
+  await setInterfaceMode(page, 'advanced');
+  await page.getByRole('button', { name: 'Configure AI' }).click();
+  const plugins = page.getByRole('dialog', { name: 'Plugins & models' });
+  const marker = plugins.locator('.plugin-option').filter({ hasText: 'Marker visual extraction' });
+  await marker.getByRole('button', { name: 'Install' }).click();
+  const confirmation = page.getByRole('dialog', { name: 'Confirm installation of Marker visual extraction' });
+  await expect(confirmation).toBeVisible();
+  await expect(confirmation).toContainText('additional disk space on this device');
+  expect(markerInstalls).toBe(0);
+  await confirmation.getByRole('button', { name: 'Install' }).click();
+  await expect.poll(() => markerInstalls).toBe(1);
+});

--- a/src/components/PluginInstallCancellation.tsx
+++ b/src/components/PluginInstallCancellation.tsx
@@ -1,17 +1,105 @@
-import { useSyncExternalStore } from 'react';
-import { Button } from 'antd';
+import { useEffect, useState, useSyncExternalStore } from 'react';
+import { Button, Space, Typography } from 'antd';
 import { StopOutlined } from '@ant-design/icons';
+import { createPortal } from 'react-dom';
 import { cancelActivePluginInstall, isPluginInstallActive, subscribePluginInstallState } from '../utils/serviceApi';
+
+interface PendingInstall {
+  button: HTMLButtonElement;
+  name: string;
+  detail: string;
+  left: number;
+  top: number;
+}
+
+const diskDetailFor = (button: HTMLButtonElement, name: string) => {
+  const option = button.closest('.plugin-option');
+  const text = option?.textContent ?? '';
+  const diskMatch = text.match(/([\d,.]+)\s*MB\s*disk/i);
+  if (diskMatch) return `Installing ${name} will use approximately ${diskMatch[1]} MB on this device.`;
+  if (/bge-m3/i.test(text)) return `Installing ${name} will use approximately 1.2 GB on this device.`;
+  if (/all-minilm/i.test(text)) return `Installing ${name} will use approximately 46 MB on this device.`;
+  return `Installing ${name} will use additional disk space on this device. The exact size varies by platform and package version.`;
+};
+
+const installNameFor = (button: HTMLButtonElement) => {
+  const option = button.closest('.plugin-option');
+  const optionName = option?.querySelector<HTMLElement>('.plugin-option-copy strong')?.textContent?.trim();
+  if (optionName) return optionName;
+  const dialog = button.closest('[role="dialog"]');
+  const title = dialog?.querySelector<HTMLElement>('.ant-modal-title')?.textContent?.replace(/settings$/i, '').trim();
+  return title || 'this component';
+};
+
+const isInstallTrigger = (button: HTMLButtonElement) => {
+  const label = button.textContent?.trim() ?? '';
+  if (!/^(Install|Download model|Download [^?]+)$/i.test(label)) return false;
+  if (button.dataset.installConfirmationBypass === 'true') return false;
+  const dialog = button.closest('[role="dialog"]');
+  const dialogText = dialog?.querySelector<HTMLElement>('.ant-modal-title')?.textContent ?? '';
+  return /Plugins & models|settings/i.test(dialogText);
+};
 
 export default function PluginInstallCancellation() {
   const active = useSyncExternalStore(subscribePluginInstallState, isPluginInstallActive, () => false);
-  if (!active) return null;
+  const [pending, setPending] = useState<PendingInstall | null>(null);
+
+  useEffect(() => {
+    const intercept = (event: MouseEvent) => {
+      if (event.defaultPrevented) return;
+      const target = event.target instanceof Element ? event.target.closest('button') : null;
+      if (!(target instanceof HTMLButtonElement) || !isInstallTrigger(target)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      const bounds = target.getBoundingClientRect();
+      const name = installNameFor(target);
+      setPending({
+        button: target,
+        name,
+        detail: diskDetailFor(target, name),
+        left: Math.min(Math.max(12, bounds.right - 320), window.innerWidth - 332),
+        top: Math.min(bounds.bottom + 8, window.innerHeight - 180),
+      });
+    };
+    document.addEventListener('click', intercept, true);
+    return () => document.removeEventListener('click', intercept, true);
+  }, []);
+
+  const confirm = () => {
+    if (!pending) return;
+    const { button } = pending;
+    setPending(null);
+    button.dataset.installConfirmationBypass = 'true';
+    try { button.click(); }
+    finally { delete button.dataset.installConfirmationBypass; }
+  };
 
   return (
-    <div role="status" aria-live="polite" style={{ position: 'fixed', right: 20, bottom: 20, zIndex: 2100 }}>
-      <Button danger type="primary" icon={<StopOutlined />} onClick={() => cancelActivePluginInstall()}>
-        Cancel plugin installation
-      </Button>
-    </div>
+    <>
+      {pending ? createPortal(
+        <div role="dialog" aria-label={`Confirm installation of ${pending.name}`} style={{
+          position: 'fixed', left: pending.left, top: pending.top, width: 320, zIndex: 2200,
+          padding: 12, borderRadius: 8, background: 'var(--panel-bg, Canvas)', boxShadow: '0 8px 30px rgb(0 0 0 / 22%)',
+          border: '1px solid var(--strong-border, ButtonBorder)',
+        }}>
+          <Space direction="vertical" size="small" style={{ width: '100%' }}>
+            <Typography.Text strong>Install {pending.name}?</Typography.Text>
+            <Typography.Text type="secondary">{pending.detail} Are you sure?</Typography.Text>
+            <Space style={{ justifyContent: 'flex-end', width: '100%' }}>
+              <Button size="small" onClick={() => setPending(null)}>Cancel</Button>
+              <Button size="small" type="primary" onClick={confirm}>Install</Button>
+            </Space>
+          </Space>
+        </div>, document.body,
+      ) : null}
+      {active ? (
+        <div role="status" aria-live="polite" style={{ position: 'fixed', right: 20, bottom: 20, zIndex: 2100 }}>
+          <Button danger type="primary" icon={<StopOutlined />} onClick={() => cancelActivePluginInstall()}>
+            Cancel plugin installation
+          </Button>
+        </div>
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
Fixes #114.

- intercept install/download actions in Plugins & Models with one consistent anchored confirmation surface
- show expected on-device disk usage when it is known (including bge-m3/all-minilm and plugin-reported disk estimates)
- show an explicit platform/package-size fallback when an exact estimate is unavailable
- preserve existing installer-specific security confirmations and the current working/log output after confirmation
- add Playwright coverage proving installation does not start until the shared confirmation is accepted

Stacked on #118 so this PR contains only the #114 delta.