### PR TITLE
fix: align Back to home with the outer test container (#121)

### DIFF
--- a/src/components/TestStart.tsx
+++ b/src/components/TestStart.tsx
@@ -26,45 +26,49 @@ const TestStart: React.FC<Props> = ({ test, draft, onStart, onResume, onOpenDocu
     const sourceDocuments = useLiveQuery(() => db.documents.bulkGet(documentIds), [test.id, documentIds.join('|')]);
 
     return <div className="test-start">
-      <Button className="test-back-button" type="text" icon={<ArrowLeftOutlined />} onClick={onBack}>Back to home</Button>
-      <div className="test-start-main">
-        <Title level={2} style={{ marginBottom: 8 }}>{test.name}</Title>
-        <Paragraph type="secondary" style={{ fontSize: 16, marginBottom: 32 }}>
-          This test contains <strong>{test.questions.length}</strong> questions
-        </Paragraph>
-        {draft && <Alert type="info" showIcon style={{ width: 'min(100%, 560px)', marginBottom: 24 }}
-          message={`Paused ${draft.practice ? 'practice' : 'test'} available`}
-          description={`Continue from question ${draft.currentIndex + 1}. Your answers, feedback, timer, and review marks are saved.`} />}
-        <Space wrap style={{ justifyContent: 'center', marginBottom: 24 }}>
-          {counts.multipleChoice > 0 && <Tag color="blue">{counts.multipleChoice} multiple choice</Tag>}
-          {counts.fillBlank > 0 && <Tag color="purple">{counts.fillBlank} fill in the blank</Tag>}
-          {counts.reasoning > 0 && <Tag color="gold">{counts.reasoning} reasoning</Tag>}
-          {counts.coding > 0 && <Tag color="cyan">{counts.coding} coding</Tag>}
-        </Space>
-        <Radio.Group value={mode} onChange={event => setMode(event.target.value)} optionType="button" buttonStyle="solid" style={{ marginBottom: 20 }}
-          options={[{ label: 'Test mode', value: 'test' }, { label: 'Practice mode', value: 'practice' }]} />
-        <Paragraph type="secondary" style={{ maxWidth: 520, marginBottom: 20 }}>
-          {mode === 'practice'
-            ? 'Check each answer immediately, study its explanation, then continue.'
-            : counts.reasoning || counts.coding
-              ? 'Complete the questions without seeing answers. After submission, reasoning and coding responses are graded by the configured AI provider before review.'
-              : 'Complete the questions first, then review your results after submitting the test.'}
-        </Paragraph>
-        <div className="test-timer-control">
-          <Checkbox checked={timed} onChange={(event) => setTimed(event.target.checked)} style={{ fontSize: 14 }}>Timed test</Checkbox>
-          {timed && <InputNumber min={1} max={240} value={durationMinutes} onChange={(value) => setDurationMinutes(value || 1)}
-            addonAfter="minutes" style={{ width: 200 }} />}
+      <section style={{ minWidth: 0, minHeight: 0, display: 'grid', gridTemplateRows: 'auto minmax(0, 1fr)', background: 'var(--surface)' }}>
+        <div style={{ padding: '12px 12px 0' }}>
+          <Button type="text" icon={<ArrowLeftOutlined />} onClick={onBack}>Back to home</Button>
         </div>
-        {draft ? <Space wrap style={{ justifyContent: 'center' }}>
-          <Button type="primary" size="large" onClick={onResume}>Resume {draft.practice ? 'Practice' : 'Test'}</Button>
-          <Popconfirm title="Start over?" description="This removes the paused session and its saved answers." onConfirm={() => onStart({
-            timeLimit: timed ? durationMinutes * 60 : undefined, practice: mode === 'practice',
-          })}><Button size="large">Start Over</Button></Popconfirm>
-        </Space> : <Button type="primary" size="large" className="test-start-button"
-          onClick={() => onStart({ timeLimit: timed ? durationMinutes * 60 : undefined, practice: mode === 'practice' })}>
-          {mode === 'practice' ? 'Start Practice' : 'Start Test'}
-        </Button>}
-      </div>
+        <div className="test-start-main" style={{ paddingTop: 32 }}>
+          <Title level={2} style={{ marginBottom: 8 }}>{test.name}</Title>
+          <Paragraph type="secondary" style={{ fontSize: 16, marginBottom: 32 }}>
+            This test contains <strong>{test.questions.length}</strong> questions
+          </Paragraph>
+          {draft && <Alert type="info" showIcon style={{ width: 'min(100%, 560px)', marginBottom: 24 }}
+            message={`Paused ${draft.practice ? 'practice' : 'test'} available`}
+            description={`Continue from question ${draft.currentIndex + 1}. Your answers, feedback, timer, and review marks are saved.`} />}
+          <Space wrap style={{ justifyContent: 'center', marginBottom: 24 }}>
+            {counts.multipleChoice > 0 && <Tag color="blue">{counts.multipleChoice} multiple choice</Tag>}
+            {counts.fillBlank > 0 && <Tag color="purple">{counts.fillBlank} fill in the blank</Tag>}
+            {counts.reasoning > 0 && <Tag color="gold">{counts.reasoning} reasoning</Tag>}
+            {counts.coding > 0 && <Tag color="cyan">{counts.coding} coding</Tag>}
+          </Space>
+          <Radio.Group value={mode} onChange={event => setMode(event.target.value)} optionType="button" buttonStyle="solid" style={{ marginBottom: 20 }}
+            options={[{ label: 'Test mode', value: 'test' }, { label: 'Practice mode', value: 'practice' }]} />
+          <Paragraph type="secondary" style={{ maxWidth: 520, marginBottom: 20 }}>
+            {mode === 'practice'
+              ? 'Check each answer immediately, study its explanation, then continue.'
+              : counts.reasoning || counts.coding
+                ? 'Complete the questions without seeing answers. After submission, reasoning and coding responses are graded by the configured AI provider before review.'
+                : 'Complete the questions first, then review your results after submitting the test.'}
+          </Paragraph>
+          <div className="test-timer-control">
+            <Checkbox checked={timed} onChange={(event) => setTimed(event.target.checked)} style={{ fontSize: 14 }}>Timed test</Checkbox>
+            {timed && <InputNumber min={1} max={240} value={durationMinutes} onChange={(value) => setDurationMinutes(value || 1)}
+              addonAfter="minutes" style={{ width: 200 }} />}
+          </div>
+          {draft ? <Space wrap style={{ justifyContent: 'center' }}>
+            <Button type="primary" size="large" onClick={onResume}>Resume {draft.practice ? 'Practice' : 'Test'}</Button>
+            <Popconfirm title="Start over?" description="This removes the paused session and its saved answers." onConfirm={() => onStart({
+              timeLimit: timed ? durationMinutes * 60 : undefined, practice: mode === 'practice',
+            })}><Button size="large">Start Over</Button></Popconfirm>
+          </Space> : <Button type="primary" size="large" className="test-start-button"
+            onClick={() => onStart({ timeLimit: timed ? durationMinutes * 60 : undefined, practice: mode === 'practice' })}>
+            {mode === 'practice' ? 'Start Practice' : 'Start Test'}
+          </Button>}
+        </div>
+      </section>
       <aside className="test-source-sidebar">
         <Typography.Title level={5} className="test-source-title"><FileTextOutlined /> Source documents</Typography.Title>
         {documentIds.length ? <div className="test-source-list">


### PR DESCRIPTION
Fixes #121.

- move the Back to home action out of the padded test-start content area
- place it in a dedicated outer toolbar above the centered test content
- preserve the existing test-start behavior and responsive two-column structure

No Plugins & Models changes.