### PR TITLE
Contain Settings and Plugins modal height

### DIFF
--- a/e2e/modal-height.spec.ts
+++ b/e2e/modal-height.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+import { dismissOnboarding, setInterfaceMode } from './helpers';
+
+const expectCentered = async (locator: import('@playwright/test').Locator, viewportHeight: number) => {
+  await expect.poll(async () => {
+    const box = await locator.boundingBox();
+    if (!box) return Number.POSITIVE_INFINITY;
+    const top = box.y;
+    const bottom = viewportHeight - (box.y + box.height);
+    return Math.abs(top - bottom);
+  }, { timeout: 3_000 }).toBeLessThanOrEqual(2);
+
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box?.y ?? 0).toBeGreaterThanOrEqual(15);
+};
+
+test('Settings and Plugins & models stay centered and scroll inside the modal', async ({ page }) => {
+  await page.setViewportSize({ width: 1200, height: 560 });
+  await dismissOnboarding(page);
+  await setInterfaceMode(page, 'advanced');
+
+  await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
+  const settings = page.getByRole('dialog', { name: 'Settings' });
+  await expect(settings).toBeVisible();
+  await expectCentered(settings, 560);
+  await settings.getByRole('button', { name: 'Cancel' }).click();
+
+  await page.getByRole('button', { name: 'Configure AI' }).click();
+  const plugins = page.getByRole('dialog', { name: 'Plugins & models' });
+  await expect(plugins).toBeVisible();
+  await plugins.getByRole('tab', { name: 'Models' }).click();
+  await expectCentered(plugins, 560);
+  const overflow = await plugins.locator('.ant-modal-body').evaluate(element => ({
+    overflowY: getComputedStyle(element).overflowY,
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  expect(overflow.overflowY).toBe('auto');
+  expect(overflow.scrollHeight).toBeGreaterThan(overflow.clientHeight);
+});

--- a/e2e/settings-prompt-width.spec.ts
+++ b/e2e/settings-prompt-width.spec.ts
@@ -6,12 +6,12 @@ test('Prompt Studio keeps the Settings modal width stable', async ({ page }) => 
   await setInterfaceMode(page, 'advanced');
   await page.locator('.sidebar-footer:visible').getByRole('button', { name: 'Settings' }).click();
   const dialog = page.getByRole('dialog', { name: 'Settings' });
-  const before = await dialog.boundingBox();
-  expect(before).not.toBeNull();
+  await expect(dialog).toBeVisible();
+  const before = await dialog.evaluate(element => (element as HTMLElement).offsetWidth);
+  expect(before).toBeGreaterThan(0);
 
   await dialog.getByRole('tab', { name: 'Prompt Studio' }).click();
   await expect(dialog.getByRole('tabpanel', { name: 'Prompt Studio' })).toBeVisible();
-  const after = await dialog.boundingBox();
-  expect(after).not.toBeNull();
-  expect(Math.abs((after?.width ?? 0) - (before?.width ?? 0))).toBeLessThan(1);
+  const after = await dialog.evaluate(element => (element as HTMLElement).offsetWidth);
+  expect(after).toBe(before);
 });

--- a/src/components/PluginsModal.css
+++ b/src/components/PluginsModal.css
@@ -1,0 +1,12 @@
+.plugins-modal .ant-modal-content {
+  max-height: calc(100dvh - 32px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.plugins-modal .ant-modal-body {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}

--- a/src/components/PluginsModal.tsx
+++ b/src/components/PluginsModal.tsx
@@ -16,6 +16,7 @@ import { getMessageApi } from '../utils/messageProvider';
 import { getModalApi } from '../utils/modalProvider';
 import { executeTwoPhaseAction, serviceFetch, serviceJson, serviceRequest } from '../utils/serviceApi';
 import { IntegrationStatusGate, PluginGlyph, PluginJobDetails } from './pluginOptionPresentation';
+import './PluginsModal.css';
 
 type JobState = 'idle' | 'working' | 'complete' | 'error';
 type AgentStatus = { installed: boolean; connected: boolean; job?: { state: JobState; message: string } };
@@ -834,7 +835,7 @@ export default function PluginsModal({ open, interfaceMode, onClose }: Props) {
 
   return (
     <>
-      <Modal open={open} title={<Space><ApiOutlined /> Plugins & models <Button type="text" size="small" icon={<ReloadOutlined />}
+      <Modal open={open} centered className="plugins-modal" title={<Space><ApiOutlined /> Plugins & models <Button type="text" size="small" icon={<ReloadOutlined />}
         loading={externalLoading} aria-label="Detect plugins and models again"
         onClick={() => { void refresh(); void refreshExternal(); }} /></Space>} width={940} onCancel={onClose} onOk={() => void save()}
         confirmLoading={saving} okButtonProps={{ disabled: !credentialReady }} okText="Save settings">

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -109,11 +109,23 @@
 }
 
 .ant-modal-wrap:has(.settings-modal) {
-  display: flex;
-  align-items: center;
+  text-align: center;
+  white-space: nowrap;
 }
 
-.settings-modal {
+.ant-modal-wrap:has(.settings-modal)::before {
+  display: inline-block;
+  width: 0;
+  height: 100%;
+  vertical-align: middle;
+  content: '';
+}
+
+.ant-modal-wrap:has(.settings-modal) .settings-modal {
   top: 0;
+  display: inline-block;
   padding-bottom: 0;
+  text-align: start;
+  vertical-align: middle;
+  white-space: normal;
 }

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -124,6 +124,8 @@
 .ant-modal-wrap:has(.settings-modal) .settings-modal {
   top: 0;
   display: inline-block;
+  width: min(960px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
   padding-bottom: 0;
   text-align: start;
   vertical-align: middle;

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -109,25 +109,14 @@
 }
 
 .ant-modal-wrap:has(.settings-modal) {
-  text-align: center;
-  white-space: nowrap;
-}
-
-.ant-modal-wrap:has(.settings-modal)::before {
-  display: inline-block;
-  width: 0;
-  height: 100%;
-  vertical-align: middle;
-  content: '';
+  display: grid;
+  place-items: center;
 }
 
 .ant-modal-wrap:has(.settings-modal) .settings-modal {
   top: 0;
-  display: inline-block;
   width: min(960px, calc(100vw - 32px));
   max-width: calc(100vw - 32px);
+  margin: 0;
   padding-bottom: 0;
-  text-align: start;
-  vertical-align: middle;
-  white-space: normal;
 }

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -107,3 +107,13 @@
 .settings-modal .settings-content-pane {
   border-radius: 12px;
 }
+
+.ant-modal-wrap:has(.settings-modal) {
+  display: flex;
+  align-items: center;
+}
+
+.settings-modal {
+  top: 0;
+  padding-bottom: 0;
+}


### PR DESCRIPTION
Fixes #141.

- vertically center Settings and Plugins & Models so top and bottom window spacing match
- cap Plugins & Models to the viewport and keep long Models content scrolling inside the modal
- add compact-viewport Playwright coverage for centering and internal overflow