### PR TITLE
Simplify accent color picker circles

### DIFF
--- a/e2e/accent-color.spec.ts
+++ b/e2e/accent-color.spec.ts
@@ -56,7 +56,7 @@ test('renders the accent picker as flush circular color controls', async ({ page
 
   await expect(trigger.locator('.accent-color-dot')).toHaveCount(0);
   await expect(trigger).toHaveCSS('border-radius', '50%');
-  await expect(trigger).toHaveCSS('background-color', 'rgb(22, 119, 255)');
+  await expect(trigger).toHaveCSS('background-color', 'rgb(0, 80, 179)');
   const triggerSize = await trigger.evaluate(element => ({
     width: (element as HTMLElement).offsetWidth,
     height: (element as HTMLElement).offsetHeight,
@@ -70,7 +70,7 @@ test('renders the accent picker as flush circular color controls', async ({ page
   await expect(blue.locator('.accent-color-dot')).toHaveCount(0);
   await expect(blue).toHaveCSS('padding-left', '0px');
   await expect(blue).toHaveCSS('padding-right', '0px');
-  await expect(blue).toHaveCSS('background-color', 'rgb(22, 119, 255)');
+  await expect(blue).toHaveCSS('background-color', 'rgb(0, 80, 179)');
   await expect(blue).toHaveCSS('border-top-width', '2px');
 });
 

--- a/e2e/accent-color.spec.ts
+++ b/e2e/accent-color.spec.ts
@@ -48,6 +48,32 @@ test('applies accents immediately in both themes and preserves the choice after 
   await expect.poll(() => primaryColor(page)).toBe('#69b1ff');
 });
 
+test('renders the accent picker as flush circular color controls', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'light' });
+  await dismissOnboarding(page);
+  const dialog = await openSettings(page);
+  const trigger = dialog.getByRole('button', { name: 'Accent color: Blue' });
+
+  await expect(trigger.locator('.accent-color-dot')).toHaveCount(0);
+  await expect(trigger).toHaveCSS('border-radius', '50%');
+  await expect(trigger).toHaveCSS('background-color', 'rgb(22, 119, 255)');
+  const triggerSize = await trigger.evaluate(element => ({
+    width: (element as HTMLElement).offsetWidth,
+    height: (element as HTMLElement).offsetHeight,
+  }));
+  expect(triggerSize.width).toBe(triggerSize.height);
+
+  await trigger.click();
+  const palette = page.getByRole('listbox', { name: 'Accent colors' });
+  const blue = palette.getByRole('option', { name: 'Blue', exact: true });
+  await expect(blue).toHaveAttribute('aria-selected', 'true');
+  await expect(blue.locator('.accent-color-dot')).toHaveCount(0);
+  await expect(blue).toHaveCSS('padding-left', '0px');
+  await expect(blue).toHaveCSS('padding-right', '0px');
+  await expect(blue).toHaveCSS('background-color', 'rgb(22, 119, 255)');
+  await expect(blue).toHaveCSS('border-top-width', '2px');
+});
+
 test('finds the accent setting by name and supports keyboard selection', async ({ page }) => {
   await dismissOnboarding(page);
   const dialog = await openSettings(page);

--- a/src/components/AccentColorSetting.tsx
+++ b/src/components/AccentColorSetting.tsx
@@ -1,5 +1,5 @@
 import { CheckOutlined } from '@ant-design/icons';
-import { Button, Popover, Space, Tag, Typography } from 'antd';
+import { Popover, Space, Tag, Typography } from 'antd';
 import { ACCENT_COLORS, type AccentColor } from '../utils/accentColor';
 import { changeAccentColor, useAccentColor } from '../utils/useAccentColor';
 import { getMessageApi } from '../utils/messageProvider';
@@ -21,10 +21,9 @@ export default function AccentColorSetting() {
       {ACCENT_COLORS.map(color => (
         <button key={color.id} type="button" role="option" aria-selected={accent === color.id}
           className={`accent-color-swatch${accent === color.id ? ' is-selected' : ''}`}
+          style={{ backgroundColor: color.light.primary }}
           aria-label={color.label} title={color.label} onClick={() => apply(color.id)}>
-          <span className="accent-color-dot" style={{ backgroundColor: color.light.primary }} aria-hidden="true">
-            {accent === color.id ? <CheckOutlined /> : null}
-          </span>
+          {accent === color.id ? <CheckOutlined /> : null}
         </button>
       ))}
     </div>
@@ -38,9 +37,9 @@ export default function AccentColorSetting() {
     </div>
     <div className="settings-control settings-control-single">
       <Popover content={palette} trigger="click" placement="bottomRight">
-        <Button className="accent-color-trigger" aria-label={`Accent color: ${selected.label}`} title={`Accent color: ${selected.label}`}>
-          <span className="accent-color-dot" style={{ backgroundColor: selected.light.primary }} aria-hidden="true" />
-        </Button>
+        <button type="button" className="accent-color-trigger"
+          style={{ backgroundColor: selected.light.primary }}
+          aria-label={`Accent color: ${selected.label}`} title={`Accent color: ${selected.label}`} />
       </Popover>
     </div>
   </div>;

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -40,20 +40,22 @@
 }
 
 .accent-color-trigger {
-  width: 36px;
-  min-width: 36px;
-  padding-inline: 0;
-}
-
-.accent-color-dot {
-  width: 20px;
-  height: 20px;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
   display: inline-grid;
   place-items: center;
+  padding: 0;
+  border: 1px solid rgb(0 0 0 / 18%);
   border-radius: 50%;
-  color: #fff;
-  box-shadow: 0 0 0 1px rgb(0 0 0 / 18%);
-  font-size: 11px;
+  appearance: none;
+  cursor: pointer;
+}
+
+.accent-color-trigger:hover,
+.accent-color-trigger:focus-visible {
+  outline: 2px solid var(--strong-border);
+  outline-offset: 2px;
 }
 
 .accent-color-palette {
@@ -68,18 +70,24 @@
   height: 32px;
   display: grid;
   place-items: center;
+  box-sizing: border-box;
   padding: 0;
-  border: 0;
+  border: 2px solid transparent;
   border-radius: 50%;
-  background: transparent;
+  appearance: none;
+  color: #fff;
+  font-size: 11px;
   cursor: pointer;
 }
 
-.accent-color-swatch:hover,
-.accent-color-swatch:focus-visible,
 .accent-color-swatch.is-selected {
+  border-color: var(--strong-border);
+}
+
+.accent-color-swatch:hover,
+.accent-color-swatch:focus-visible {
   outline: 2px solid var(--strong-border);
-  outline-offset: 1px;
+  outline-offset: 2px;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
- render the current accent as a single circular color button instead of an AntD button containing a smaller dot
- render palette choices as the colored circles themselves, with the selected border directly touching the fill
- keep keyboard/accessibility behavior and add Playwright coverage for the flat circular controls