### PR TITLE
fix(documents): add tags to all pending uploads

### DIFF
--- a/e2e/documents.spec.ts
+++ b/e2e/documents.spec.ts
@@ -39,3 +39,21 @@ test('document tags are individual items and technical details live in a popover
   await documentView.getByRole('textbox', { name: 'Add tag to study-guide' }).press('Enter');
   await expect(documentView.getByText('review', { exact: true })).toBeVisible();
 });
+
+test('bulk tags apply to every document in the upload', async ({ page }) => {
+  await dismissOnboarding(page);
+  await page.getByRole('button', { name: 'Add documents' }).last().click();
+
+  const dialog = page.getByRole('dialog', { name: 'Add documents' });
+  await dialog.locator('input[type="file"]').setInputFiles([
+    { name: 'alpha.txt', mimeType: 'text/plain', buffer: Buffer.from('Alpha notes') },
+    { name: 'beta.txt', mimeType: 'text/plain', buffer: Buffer.from('Beta notes') },
+  ]);
+  await expect(dialog.getByText('ready', { exact: true })).toHaveCount(2);
+
+  await dialog.getByRole('button', { name: 'Add tag to all uploading documents' }).click();
+  await dialog.getByRole('textbox', { name: 'Add tag to all uploading documents' }).fill('shared');
+  await dialog.getByRole('textbox', { name: 'Add tag to all uploading documents' }).press('Enter');
+
+  await expect(dialog.getByText('shared', { exact: true })).toHaveCount(3);
+});

--- a/src/components/AddDocumentModal.tsx
+++ b/src/components/AddDocumentModal.tsx
@@ -38,11 +38,22 @@ const hashText = (value: string) => hashBytes(new TextEncoder().encode(value));
 export default function AddDocumentModal({ onClose, onCreated }: Props) {
   const toolSettings = getProviderSettings().enabledTools;
   const [files, setFiles] = useState<PendingDocument[]>([]);
+  const [bulkTags, setBulkTags] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const message = getMessageApi();
 
   const update = (id: string, changes: Partial<PendingDocument>) =>
     setFiles(current => current.map(item => item.id === id ? { ...item, ...changes } : item));
+
+  const applyBulkTags = (tags: string[]) => {
+    const added = tags.filter(tag => !bulkTags.includes(tag));
+    const removed = bulkTags.filter(tag => !tags.includes(tag));
+    setBulkTags(tags);
+    setFiles(current => current.map(item => ({
+      ...item,
+      tags: [...item.tags.filter(tag => !removed.includes(tag)), ...added.filter(tag => !item.tags.includes(tag))],
+    })));
+  };
 
   const extract = async (id: string, file: RcFile) => {
     update(id, { status: 'extracting', stage: 'Reading document…', error: undefined, extracted: undefined });
@@ -87,7 +98,7 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
       id,
       file,
       name: file.name.replace(/\.[^/.]+$/, ''),
-      tags: [],
+      tags: [...bulkTags],
       status: 'extracting',
       stage: 'Queued…',
     };
@@ -147,6 +158,12 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
         <p className="ant-upload-drag-icon"><InboxOutlined /></p>
         <p className="ant-upload-text">Drop PDF, text, or Markdown documents here</p>
       </Upload.Dragger>
+      {files.length > 0 ? (
+        <div style={{ marginTop: 16 }}>
+          <TagEditor tags={bulkTags} subject="all uploading documents" onChange={applyBulkTags} />
+          <Typography.Text type="secondary">Changes here are applied to every document currently in this upload, and to files added afterward.</Typography.Text>
+        </div>
+      ) : null}
       {extractingCount > 0 && <Alert style={{ marginTop: 16 }} type="info" showIcon icon={<Spin size="small" />}
         message={`Extracting ${extractingCount} document${extractingCount === 1 ? '' : 's'}`}
         description="You can keep editing names and tags while extraction finishes." />}


### PR DESCRIPTION
Closes #159

- adds a bulk tag editor to the Add documents modal
- applies bulk tag changes to every pending upload
- carries bulk tags into files added afterward
- adds Playwright coverage for applying one tag across multiple files