### PR TITLE
fix(plugins): use one confirmation for installs

### DIFF
--- a/e2e/embedding-install.spec.ts
+++ b/e2e/embedding-install.spec.ts
@@ -42,9 +42,7 @@ test('confirmed bge-m3 download selects the model before starting installation',
   await expect(installConfirm).toContainText('1.2 GB');
   await installConfirm.getByRole('button', { name: 'Install' }).click();
 
-  const confirmation = page.locator('.ant-modal-confirm').filter({ hasText: 'Download bge-m3 for dense retrieval?' });
-  await expect(confirmation).toBeVisible();
-  await confirmation.getByRole('button', { name: 'Download bge-m3' }).click();
+  await expect(page.locator('.ant-modal-confirm').filter({ hasText: 'Download bge-m3 for dense retrieval?' })).toHaveCount(0);
   await expect.poll(() => requests.filter(value => value.startsWith('install:'))).toEqual(['install:bge-m3:true']);
   await expect.poll(() => requests.some(value => value === 'settings:bge-m3')).toBe(true);
 });

--- a/e2e/plugin-install-confirmation.spec.ts
+++ b/e2e/plugin-install-confirmation.spec.ts
@@ -3,18 +3,19 @@ import { dismissOnboarding, setInterfaceMode } from './helpers';
 
 const idleJob = { state: 'idle', message: '' };
 
+const integrationStatus = (embeddings: { installed: boolean; model: string } = { installed: true, model: 'all-minilm' }) => ({
+  marker: { installed: false, managed: false, job: idleJob }, ocr: { installed: true, managed: true, job: idleJob },
+  codex: { installed: true, connected: true, job: idleJob }, 'claude-agent': { installed: true, connected: true, job: idleJob },
+  'antigravity-agent': { installed: true, connected: true, job: idleJob },
+  ollama: { installed: true, serverReady: true, models: [], job: idleJob },
+  'llama-cpp': { configured: false, serverReady: false, models: [], capabilities: [] },
+  embeddings: { ...embeddings, runtimeInstalled: true, job: idleJob },
+});
+
 test('plugin installation asks for disk-space confirmation before starting', async ({ page }) => {
   let markerInstalls = 0;
   await page.route('**/api/integrations', route => route.fulfill({
-    contentType: 'application/json',
-    body: JSON.stringify({
-      marker: { installed: false, managed: false, job: idleJob }, ocr: { installed: true, managed: true, job: idleJob },
-      codex: { installed: true, connected: true, job: idleJob }, 'claude-agent': { installed: true, connected: true, job: idleJob },
-      'antigravity-agent': { installed: true, connected: true, job: idleJob },
-      ollama: { installed: true, serverReady: true, models: [], job: idleJob },
-      'llama-cpp': { configured: false, serverReady: false, models: [], capabilities: [] },
-      embeddings: { installed: true, runtimeInstalled: true, model: 'all-minilm', job: idleJob },
-    }),
+    contentType: 'application/json', body: JSON.stringify(integrationStatus()),
   }));
   await page.route('**/api/integrations/marker/install', route => { markerInstalls += 1; return route.fulfill({ status: 202, contentType: 'application/json', body: JSON.stringify({ ok: true }) }); });
   await dismissOnboarding(page);
@@ -29,4 +30,31 @@ test('plugin installation asks for disk-space confirmation before starting', asy
   expect(markerInstalls).toBe(0);
   await confirmation.getByRole('button', { name: 'Install' }).click();
   await expect.poll(() => markerInstalls).toBe(1);
+});
+
+test('bge-m3 uses the popover as its only install confirmation', async ({ page }) => {
+  let installs = 0;
+  await page.route('**/api/integrations', route => route.fulfill({
+    contentType: 'application/json', body: JSON.stringify(integrationStatus({ installed: false, model: 'bge-m3' })),
+  }));
+  await page.route('**/api/integrations/embeddings/install', route => {
+    installs += 1;
+    return route.fulfill({ status: 202, contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+  await dismissOnboarding(page);
+  await setInterfaceMode(page, 'advanced');
+  await page.getByRole('button', { name: 'Configure AI' }).click();
+
+  const plugins = page.getByRole('dialog', { name: 'Plugins & models' });
+  await plugins.getByRole('tab', { name: 'Embeddings' }).click();
+  const embeddings = plugins.locator('.plugin-option').filter({ hasText: 'Ollama embeddings · bge-m3' });
+  await embeddings.getByRole('button', { name: 'Install' }).click();
+
+  const confirmation = page.getByRole('dialog', { name: 'Confirm installation of Ollama embeddings · bge-m3' });
+  await expect(confirmation).toBeVisible();
+  await expect(confirmation).toContainText('1.2 GB');
+  await confirmation.getByRole('button', { name: 'Install' }).click();
+
+  await expect.poll(() => installs).toBe(1);
+  await expect(page.getByRole('dialog', { name: /Download bge-m3 for dense retrieval/i })).toHaveCount(0);
 });

--- a/src/components/PluginInstallCancellation.tsx
+++ b/src/components/PluginInstallCancellation.tsx
@@ -3,6 +3,7 @@ import { Button, Space, Typography } from 'antd';
 import { StopOutlined } from '@ant-design/icons';
 import { createPortal } from 'react-dom';
 import { cancelActivePluginInstall, isPluginInstallActive, subscribePluginInstallState } from '../utils/serviceApi';
+import { allowConfirmedInstallHandoff } from '../utils/modalProvider';
 import ImmediateSettingsPersistence from './ImmediateSettingsPersistence';
 
 interface PendingInstall {
@@ -71,6 +72,7 @@ export default function PluginInstallCancellation() {
     if (!pending) return;
     const { button } = pending;
     setPending(null);
+    allowConfirmedInstallHandoff();
     button.dataset.installConfirmationBypass = 'true';
     try { button.click(); }
     finally { delete button.dataset.installConfirmationBypass; }

--- a/src/utils/modalProvider.ts
+++ b/src/utils/modalProvider.ts
@@ -29,7 +29,7 @@ export const getModalApi = (): HookAPI => {
         if (!isInstallConfirmation(config)) return target.confirm(config);
         installConfirmationBypassUntil = 0;
         void Promise.resolve(config.onOk?.(() => undefined));
-        return { destroy: () => undefined, update: () => undefined } as ReturnType<HookAPI['confirm']>;
+        return { destroy: () => undefined, update: () => undefined } as unknown as ReturnType<HookAPI['confirm']>;
       };
     },
   });

--- a/src/utils/modalProvider.ts
+++ b/src/utils/modalProvider.ts
@@ -1,12 +1,36 @@
 import type { HookAPI } from 'antd/es/modal/useModal';
 
 let modalApi: HookAPI | null = null;
+let installConfirmationBypassUntil = 0;
 
 export const setModalApi = (api: HookAPI) => {
   modalApi = api;
 };
 
+export const allowConfirmedInstallHandoff = (durationMs = 1500) => {
+  installConfirmationBypassUntil = Date.now() + durationMs;
+};
+
+const isInstallConfirmation = (config: Parameters<HookAPI['confirm']>[0]) => {
+  const title = typeof config.title === 'string' ? config.title : '';
+  const okText = typeof config.okText === 'string' ? config.okText : '';
+  return /^(install|download|update)\b/i.test(title.trim())
+    || /^(install|download|confirm and install|confirm and update)\b/i.test(okText.trim());
+};
+
 export const getModalApi = (): HookAPI => {
   if (!modalApi) throw new Error('Modal API has not been initialized');
-  return modalApi;
+  if (Date.now() >= installConfirmationBypassUntil) return modalApi;
+
+  return new Proxy(modalApi, {
+    get(target, property, receiver) {
+      if (property !== 'confirm') return Reflect.get(target, property, receiver);
+      return (config: Parameters<HookAPI['confirm']>[0]) => {
+        if (!isInstallConfirmation(config)) return target.confirm(config);
+        installConfirmationBypassUntil = 0;
+        void Promise.resolve(config.onOk?.(() => undefined));
+        return { destroy: () => undefined, update: () => undefined } as ReturnType<HookAPI['confirm']>;
+      };
+    },
+  });
 };


### PR DESCRIPTION
Closes #156

- makes the existing install popover the single user confirmation
- suppresses install/download/update Modal.confirm calls only during the confirmed install handoff
- covers bge-m3 specifically so it no longer opens a second confirmation modal
- keeps non-install confirmations unchanged