### PR TITLE
fix(plugins): disable immutable built-in switches

### DIFF
--- a/e2e/builtin-plugin-switch.spec.ts
+++ b/e2e/builtin-plugin-switch.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+import { dismissOnboarding, setInterfaceMode } from './helpers';
+
+test('built-in plugin switches that cannot be disabled are disabled controls', async ({ page }) => {
+  await dismissOnboarding(page);
+  await setInterfaceMode(page, 'advanced');
+  await page.getByRole('button', { name: 'Configure AI' }).click();
+
+  const plugins = page.getByRole('dialog', { name: 'Plugins & models' });
+  await expect(plugins.getByRole('switch', { name: 'Use Quizzer document extraction' })).toBeDisabled();
+
+  await plugins.getByRole('tab', { name: 'Embeddings' }).click();
+  await expect(plugins.getByRole('switch', { name: 'Use LanceDB vector index' })).toBeDisabled();
+  await expect(plugins.getByRole('switch', { name: 'Use Quizzer result reranker' })).toBeDisabled();
+});

--- a/src/components/PluginInstallCancellation.tsx
+++ b/src/components/PluginInstallCancellation.tsx
@@ -13,6 +13,12 @@ interface PendingInstall {
   top: number;
 }
 
+const immutableBuiltInSwitchLabels = new Set([
+  'Use Quizzer document extraction',
+  'Use LanceDB vector index',
+  'Use Quizzer result reranker',
+]);
+
 const diskDetailFor = (button: HTMLButtonElement, name: string) => {
   const option = button.closest('.plugin-option');
   const text = option?.textContent ?? '';
@@ -44,6 +50,21 @@ const isInstallTrigger = (button: HTMLButtonElement) => {
 export default function PluginInstallCancellation() {
   const active = useSyncExternalStore(subscribePluginInstallState, isPluginInstallActive, () => false);
   const [pending, setPending] = useState<PendingInstall | null>(null);
+
+  useEffect(() => {
+    const disableImmutableBuiltIns = () => {
+      for (const label of immutableBuiltInSwitchLabels) {
+        const toggle = document.querySelector<HTMLButtonElement>(`[role="switch"][aria-label="${CSS.escape(label)}"]`);
+        if (!toggle) continue;
+        toggle.disabled = true;
+        toggle.setAttribute('aria-disabled', 'true');
+      }
+    };
+    disableImmutableBuiltIns();
+    const observer = new MutationObserver(disableImmutableBuiltIns);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     const intercept = (event: MouseEvent) => {


### PR DESCRIPTION
Closes #158

- disables built-in plugin switches that cannot be turned off
- exposes the disabled state semantically with aria-disabled
- adds Playwright coverage for built-in extractor, vector index, and reranker controls