### PR TITLE
fix(documents): keep extraction jobs alive after modal close

### DIFF
--- a/e2e/document-extraction-persistence.spec.ts
+++ b/e2e/document-extraction-persistence.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+import { dismissOnboarding } from './helpers';
+
+test('document extraction survives modal close and appears in Activity', async ({ page }) => {
+  let releaseExtraction: (() => void) | undefined;
+  const gate = new Promise<void>(resolve => { releaseExtraction = resolve; });
+  await page.route('**/api/extract', async route => {
+    await gate;
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ content: 'Persisted extraction content', parserVersion: 'test-extractor' }),
+    });
+  });
+
+  await dismissOnboarding(page);
+  await page.getByRole('button', { name: 'Add documents' }).last().click();
+  let dialog = page.getByRole('dialog', { name: 'Add documents' });
+  await dialog.locator('input[type="file"]').setInputFiles({
+    name: 'persistent.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('Fallback content'),
+  });
+  await expect(dialog.getByText('Extracting', { exact: true })).toBeVisible();
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+
+  const activityButton = page.locator('.sidebar-footer:visible').getByRole('button', { name: /job active/i });
+  await expect(activityButton).toBeVisible();
+  await activityButton.click();
+  const activity = page.getByRole('dialog', { name: 'Activity' });
+  await activity.getByRole('tab', { name: 'Document indexing' }).click();
+  await expect(activity.getByText('Extract persistent')).toBeVisible();
+  await expect(activity.getByText('Document extraction · survives closing Add documents')).toBeVisible();
+  await activity.getByRole('button', { name: 'Close' }).click();
+
+  releaseExtraction?.();
+
+  await page.getByRole('button', { name: 'Add documents' }).last().click();
+  dialog = page.getByRole('dialog', { name: 'Add documents' });
+  await expect(dialog.locator('input[value="persistent"]')).toBeVisible();
+  await expect(dialog.getByText('ready', { exact: true })).toBeVisible();
+  await expect(dialog.getByRole('button', { name: 'Add to library' })).toBeVisible();
+});

--- a/src/components/AddDocumentModal.tsx
+++ b/src/components/AddDocumentModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 import { Alert, Button, Input, List, Modal, Space, Spin, Tag, Upload, Typography } from 'antd';
 import { InboxOutlined, ReloadOutlined } from '@ant-design/icons';
 import type { RcFile } from 'antd/es/upload';
@@ -9,20 +9,9 @@ import { getMessageApi } from '../utils/messageProvider';
 import { chunkDocumentContent, STRUCTURAL_CHUNKER_VERSION } from '../utils/documentChunks';
 import { getProviderSettings } from '../utils/providerSettings';
 import { serviceFetch } from '../utils/serviceApi';
+import { pendingDocumentImports, type PendingDocumentImport } from '../utils/pendingDocumentImports';
 import { ErrorDisplay } from './ErrorDisplay';
 import TagEditor from './TagEditor';
-
-interface PendingDocument {
-  id: string;
-  file: RcFile;
-  name: string;
-  tags: string[];
-  status: 'extracting' | 'ready' | 'error';
-  stage?: string;
-  error?: string;
-  extracted?: Pick<StoredDocument,
-    'content' | 'pageCount' | 'images' | 'parserVersion' | 'extractionSchemaVersion' | 'extractedAt' | 'extractionContentHash'>;
-}
 
 interface Props {
   onClose: () => void;
@@ -37,22 +26,21 @@ const hashText = (value: string) => hashBytes(new TextEncoder().encode(value));
 
 export default function AddDocumentModal({ onClose, onCreated }: Props) {
   const toolSettings = getProviderSettings().enabledTools;
-  const [files, setFiles] = useState<PendingDocument[]>([]);
+  const files = useSyncExternalStore(pendingDocumentImports.subscribe, pendingDocumentImports.getSnapshot, pendingDocumentImports.getSnapshot);
   const [bulkTags, setBulkTags] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const message = getMessageApi();
 
-  const update = (id: string, changes: Partial<PendingDocument>) =>
-    setFiles(current => current.map(item => item.id === id ? { ...item, ...changes } : item));
+  const update = (id: string, changes: Partial<PendingDocumentImport>) => pendingDocumentImports.update(id, changes);
 
   const applyBulkTags = (tags: string[]) => {
     const added = tags.filter(tag => !bulkTags.includes(tag));
     const removed = bulkTags.filter(tag => !tags.includes(tag));
     setBulkTags(tags);
-    setFiles(current => current.map(item => ({
-      ...item,
-      tags: [...item.tags.filter(tag => !removed.includes(tag)), ...added.filter(tag => !item.tags.includes(tag))],
-    })));
+    pendingDocumentImports.replaceTags(item => [
+      ...item.tags.filter(tag => !removed.includes(tag)),
+      ...added.filter(tag => !item.tags.includes(tag)),
+    ]);
   };
 
   const extract = async (id: string, file: RcFile) => {
@@ -94,15 +82,14 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
 
   const addFile = (file: RcFile) => {
     const id = uuidv4();
-    const pending: PendingDocument = {
+    pendingDocumentImports.add({
       id,
       file,
       name: file.name.replace(/\.[^/.]+$/, ''),
       tags: [...bulkTags],
       status: 'extracting',
       stage: 'Queued…',
-    };
-    setFiles(current => [...current, pending]);
+    });
     void extract(id, file);
     return false;
   };
@@ -134,6 +121,7 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
           chunks: chunkDocumentContent(item.extracted!.content),
         });
       }
+      pendingDocumentImports.removeMany(ready.map(item => item.id));
       message.success(`${ready.length} document(s) added`);
       await onCreated(ready[0].id);
     } finally {
@@ -166,13 +154,13 @@ export default function AddDocumentModal({ onClose, onCreated }: Props) {
       ) : null}
       {extractingCount > 0 && <Alert style={{ marginTop: 16 }} type="info" showIcon icon={<Spin size="small" />}
         message={`Extracting ${extractingCount} document${extractingCount === 1 ? '' : 's'}`}
-        description="You can keep editing names and tags while extraction finishes." />}
+        description="Extraction continues if you close this modal. Reopen Add documents to review the completed files." />}
       <List style={{ marginTop: 16, maxHeight: 330, overflow: 'auto' }} dataSource={files}
         renderItem={item => (
           <List.Item actions={item.status === 'error' ? [
             <Button key="retry" size="small" icon={<ReloadOutlined />} onClick={() => void extract(item.id, item.file)}>Retry</Button>,
-            <Button key="remove" danger size="small" onClick={() => setFiles(all => all.filter(file => file.id !== item.id))}>Remove</Button>,
-          ] : [<Button key="remove" danger size="small" onClick={() => setFiles(all => all.filter(file => file.id !== item.id))}>Remove</Button>]}>
+            <Button key="remove" danger size="small" onClick={() => pendingDocumentImports.remove(item.id)}>Remove</Button>,
+          ] : [<Button key="remove" danger size="small" onClick={() => pendingDocumentImports.remove(item.id)}>Remove</Button>]}>
             <Space direction="vertical" style={{ width: '100%' }}>
               <Space><Input value={item.name} onChange={event => update(item.id, { name: event.target.value })} />
                 <Tag color={item.status === 'ready' ? 'success' : item.status === 'error' ? 'error' : 'processing'}>

--- a/src/components/GenerationCenter.tsx
+++ b/src/components/GenerationCenter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import { Alert, Button, Checkbox, Collapse, Empty, Input, InputNumber, List, Modal, Popconfirm, Progress, Select, Space, Tabs, Tag, Typography } from 'antd';
 import { ErrorDisplay } from './ErrorDisplay';
 import { formatErrorMessage } from '../utils/errorFormatting';
@@ -15,6 +15,7 @@ import { useConfiguredProviders } from '../utils/useConfiguredProviders';
 import { serviceJson } from '../utils/serviceApi';
 import { applyServiceRecord } from '../db/serverSync';
 import { summarizeGenerationRejections } from '../utils/generationRejections';
+import { pendingDocumentImports } from '../utils/pendingDocumentImports';
 
 const terminalStatuses = new Set(['completed', 'cancelled']);
 const statusColor: Record<StoredGenerationJob['status'], string> = {
@@ -366,6 +367,7 @@ interface CenterProps { open: boolean; onClose: () => void; onOpenTest: (id: str
 export function GenerationCenter({ open, onClose, onOpenTest, onManagePlugins }: CenterProps) {
   const jobs = useLiveQuery(() => db.generationJobs.orderBy('createdAt').reverse().toArray(), []) ?? [];
   const indexJobs = useLiveQuery(() => db.indexJobs.orderBy('createdAt').reverse().toArray(), []) ?? [];
+  const extractionJobs = useSyncExternalStore(pendingDocumentImports.subscribe, pendingDocumentImports.getSnapshot, pendingDocumentImports.getSnapshot);
   const finishedGenerationIds = jobs.filter(job => terminalStatuses.has(job.status)).map(job => job.id);
   const finishedIndexIds = indexJobs.filter(job => terminalStatuses.has(job.status)).map(job => job.id);
   return <Modal open={open} width={780} title="Activity" footer={null} onCancel={onClose}>
@@ -384,7 +386,19 @@ export function GenerationCenter({ open, onClose, onOpenTest, onManagePlugins }:
         label: 'Document indexing',
         children: <Space direction="vertical" size="middle" style={{ width: '100%' }}>
           {!!finishedIndexIds.length && <Button size="small" onClick={() => void db.indexJobs.bulkDelete(finishedIndexIds)}>Clear finished</Button>}
-          <List locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No indexing jobs" /> }} dataSource={indexJobs}
+          {!!extractionJobs.length && <List dataSource={extractionJobs} renderItem={job => <List.Item className="generation-job">
+            <Space direction="vertical" size="small" style={{ width: '100%' }}>
+              <div className="generation-job-heading">
+                <div><Typography.Text strong><DatabaseOutlined /> Extract {job.name || job.file.name}</Typography.Text><br />
+                  <Typography.Text type="secondary">Document extraction · survives closing Add documents</Typography.Text></div>
+                <Tag color={job.status === 'ready' ? 'success' : job.status === 'error' ? 'error' : 'processing'}>{job.status}</Tag>
+              </div>
+              {job.stage && <Typography.Text type="secondary">{job.stage}</Typography.Text>}
+              {job.error && <ErrorDisplay error={job.error} context="document" />}
+              {job.status === 'ready' && <Alert type="success" showIcon message="Extraction finished" description="Open Add documents to review metadata and add this document to the library." />}
+            </Space>
+          </List.Item>} />}
+          <List locale={{ emptyText: extractionJobs.length ? null : <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No indexing jobs" /> }} dataSource={indexJobs}
             renderItem={job => <IndexJobItem job={job} />} />
         </Space>,
       },

--- a/src/utils/pendingDocumentImports.ts
+++ b/src/utils/pendingDocumentImports.ts
@@ -1,0 +1,63 @@
+import type { RcFile } from 'antd/es/upload';
+import type { StoredDocument } from '../db/db';
+
+export interface PendingDocumentImport {
+  id: string;
+  file: RcFile;
+  name: string;
+  tags: string[];
+  status: 'extracting' | 'ready' | 'error';
+  stage?: string;
+  error?: string;
+  extracted?: Pick<StoredDocument,
+    'content' | 'pageCount' | 'images' | 'parserVersion' | 'extractionSchemaVersion' | 'extractedAt' | 'extractionContentHash'>;
+}
+
+let items: PendingDocumentImport[] = [];
+let snapshot = items;
+let activitySnapshot = { count: 0, running: 0, attention: 0 };
+const listeners = new Set<() => void>();
+
+const emit = () => {
+  snapshot = items;
+  const running = snapshot.filter(item => item.status === 'extracting').length;
+  const attention = snapshot.filter(item => item.status === 'error').length;
+  activitySnapshot = { count: running + attention, running, attention };
+  for (const listener of listeners) listener();
+};
+
+export const pendingDocumentImports = {
+  subscribe(listener: () => void) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot() {
+    return snapshot;
+  },
+  add(item: PendingDocumentImport) {
+    items = [...items, item];
+    emit();
+  },
+  update(id: string, changes: Partial<PendingDocumentImport>) {
+    items = items.map(item => item.id === id ? { ...item, ...changes } : item);
+    emit();
+  },
+  remove(id: string) {
+    items = items.filter(item => item.id !== id);
+    emit();
+  },
+  removeMany(ids: string[]) {
+    const removed = new Set(ids);
+    items = items.filter(item => !removed.has(item.id));
+    emit();
+  },
+  replaceTags(transform: (item: PendingDocumentImport) => string[]) {
+    items = items.map(item => ({ ...item, tags: transform(item) }));
+    emit();
+  },
+};
+
+export const pendingDocumentImportActivity = {
+  subscribe: pendingDocumentImports.subscribe,
+  getSnapshot: () => activitySnapshot,
+};

--- a/src/utils/useActivitySummary.ts
+++ b/src/utils/useActivitySummary.ts
@@ -1,5 +1,7 @@
+import { useSyncExternalStore } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '../db/db';
+import { pendingDocumentImportActivity } from './pendingDocumentImports';
 
 export function useActivitySummary() {
   const activity = useLiveQuery(async () => {
@@ -9,11 +11,18 @@ export function useActivitySummary() {
     ]);
     return { generation, indexing };
   }, []);
-  const count = (activity?.generation.length ?? 0) + (activity?.indexing.length ?? 0);
+  const extraction = useSyncExternalStore(
+    pendingDocumentImportActivity.subscribe,
+    pendingDocumentImportActivity.getSnapshot,
+    pendingDocumentImportActivity.getSnapshot,
+  );
+  const count = (activity?.generation.length ?? 0) + (activity?.indexing.length ?? 0) + extraction.count;
   const running = (activity?.generation.filter(job => job.status === 'running').length ?? 0)
-    + (activity?.indexing.filter(job => job.status === 'running').length ?? 0);
+    + (activity?.indexing.filter(job => job.status === 'running').length ?? 0)
+    + extraction.running;
   const attention = (activity?.generation.filter(job => job.status === 'paused' || job.status === 'waiting' || job.status === 'error').length ?? 0)
-    + (activity?.indexing.filter(job => job.status === 'failed').length ?? 0);
+    + (activity?.indexing.filter(job => job.status === 'failed').length ?? 0)
+    + extraction.attention;
 
   return { count, running, attention };
 }


### PR DESCRIPTION
Closes #160

- moves pending document extraction state out of the modal into an app-lifetime external store
- lets extraction continue after the Add documents modal closes
- restores pending/ready files when the modal is reopened
- includes active/failed extraction work in the global Activity count
- adds Playwright coverage for closing the modal mid-extraction and reopening it